### PR TITLE
fix(ATOM-SW-): Add get_min_max_intensity; fix minMaxLoc crash

### DIFF
--- a/Software/acvision/include/camera/camera.hpp
+++ b/Software/acvision/include/camera/camera.hpp
@@ -8,6 +8,7 @@
 #pragma once 
 
 #include <opencv2/videoio.hpp> 
+#include <opencv2/core.hpp> // FIX para cv::Mat, cv::Point;
 #include <string>
 
 /**
@@ -68,6 +69,16 @@ namespace ac {
          * The caller is responsible for checking if the returned cv::Mat is empty before using it.
          */
         cv::Mat capture_frame();
+
+
+        /**
+         * @brief Localiza os valores de intensidade mínima e máxima no frame atual.
+         * @details Converte o frame internamente para tons de cinza para evitar falhas de 
+         * asserção do OpenCV com matrizes multi-canal (Issue #26).
+         * * @param[out] min_val Ponteiro para armazenar o valor mínimo encontrado.
+         * @param[out] max_val Ponteiro para armazenar o valor máximo encontrado.
+         */
+        void get_min_max_intensity(double* min_val, double* max_val);
 
         /**
          * @brief Checks the current state of the hardware link.

--- a/Software/acvision/include/camera/camera.hpp
+++ b/Software/acvision/include/camera/camera.hpp
@@ -72,11 +72,11 @@ namespace ac {
 
 
         /**
-         * @brief Localiza os valores de intensidade mínima e máxima no frame atual.
-         * @details Converte o frame internamente para tons de cinza para evitar falhas de 
-         * asserção do OpenCV com matrizes multi-canal (Issue #26).
-         * * @param[out] min_val Ponteiro para armazenar o valor mínimo encontrado.
-         * @param[out] max_val Ponteiro para armazenar o valor máximo encontrado.
+         * @brief Finds the minimum and maximum intensity values in the current frame.
+         * @details Converts the frame internally to grayscale to avoid OpenCV assertion
+         * failures with multi-channel matrices (Issue #26).
+         * @param[out] min_val Pointer used to store the minimum value found.
+         * @param[out] max_val Pointer used to store the maximum value found.
          */
         void get_min_max_intensity(double* min_val, double* max_val);
 

--- a/Software/acvision/src/camera/camera.cpp
+++ b/Software/acvision/src/camera/camera.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "camera/camera.hpp"
+#include <opencv2/imgproc.hpp> //cv::cvtColor e cv::COLOR_BGR2GRAY;
 #include <iostream>
 
 namespace ac {
@@ -75,6 +76,26 @@ cv::Mat Camera::capture_frame() {
     std::cerr << "[ACVISION][WARNING]: Frame dropped from device " << m_id << std::endl;
 }
 return frame;
+}
+
+/**
+ * @brief Localiza valores de intensidade mínima e máxima.
+ * @details Converte o frame BGR para 1 canal (Grayscale) para evitar crash no cv::minMaxLoc.
+ */
+void Camera::get_min_max_intensity(double* min_val, double* max_val) {
+    cv::Mat frame = capture_frame();
+    
+    if (frame.empty()) {
+        if (min_val) *min_val = 0.0;
+        if (max_val) *max_val = 0.0;
+        return;
+    }
+
+    //  Fix está aqui:
+    cv::Mat gray;
+    cv::cvtColor(frame, gray, cv::COLOR_BGR2GRAY); // BGR (3 canais) -> Gray (1 canal)
+    
+    cv::minMaxLoc(gray, min_val, max_val);
 }
 
 bool Camera::is_opened() const {


### PR DESCRIPTION
fix(ATOM-SW-): Add Camera::get_min_max_intensity and related includes to avoid cv::minMaxLoc assertions on multi-channel frames (Issue #26). The new method captures the current frame, handles empty frames by setting min/max to 0, converts BGR frames to grayscale with cv::cvtColor, and then calls cv::minMaxLoc. Also add <opencv2/core.hpp> to the header and <opencv2/imgproc.hpp> to the cpp. Changes made in include/camera/camera.hpp and src/camera/camera.cpp.

Closes #26