### PR TITLE
Fix #25: add explicit string include

### DIFF
--- a/Software/acvision/apps/capture_gui.cpp
+++ b/Software/acvision/apps/capture_gui.cpp
@@ -3,6 +3,7 @@
 #include <opencv2/imgproc.hpp>
 #include <iostream>
 #include <chrono>
+#include <string>
 
 #include "fen_generator/fen_generator.hpp"
 


### PR DESCRIPTION
## Summary

Added an explicit `#include <string>` to `capture_gui.cpp`, which uses `std::string`.

This avoids relying on transitive includes from `camera.hpp` and makes the build less brittle if headers change later.

## Tests

- Ran `cmake -S Software/acvision -B Software/acvision/build`
- Ran `cmake --build Software/acvision/build`