### PR TITLE
test: refactor board geometry test to use real image and BoardDetecto…

### DIFF
--- a/software/acvision/tests/test_board_geometry.cpp
+++ b/software/acvision/tests/test_board_geometry.cpp
@@ -1,44 +1,34 @@
-// #include <gtest/gtest.h>
-// #include <string> // Correção explícita para o bug #25
-// #include <vector>
-// #include "board_geometry/board_geometry.hpp"
+#include <gtest/gtest.h>
+#include <opencv2/opencv.hpp>
+#include <string>
+#include <optional>
+#include "board_vision/board_vision.hpp"
 
-// // Teste para a Task 1.3: Homografia
-// TEST(BoardGeometryTest, TestHomografiaEComputacaoDeMatriz) {
-//     // Cria uma imagem preta de 1080p simulando o frame da câmera
-//     cv::Mat frameOriginal(1080, 1920, CV_8UC3, cv::Scalar(0, 0, 0));
+// Teste focado no fluxo real que o Enzo implementou
+TEST(BoardVisionTest, TestRealBoardDetectionAndGeometry) {
+    // 1. Carrega a imagem real que o Enzo disponibilizou
+    std::string imagePath = "software/acvision/tests/images/chessboard.png";
+    cv::Mat srcImage = cv::imread(imagePath);
     
-//     // Simula 4 cantos em perspectiva capturados no frame
-//     std::vector<cv::Point2f> cantosFicticios = {
-//         cv::Point2f(200, 150), cv::Point2f(800, 100),
-//         cv::Point2f(850, 750), cv::Point2f(150, 700)
-//     };
+    // Garante que o arquivo de imagem foi aberto com sucesso
+    ASSERT_FALSE(srcImage.empty()) << "Erro: Nao foi possivel carregar a imagem de teste em: " << imagePath;
 
-//     cv::Mat topDown = corrigirPerspectiva(frameOriginal, cantosFicticios);
-    
-//     // Verifica se a homografia gerou a imagem retificada no tamanho esperado (1000x1000)
-//     EXPECT_FALSE(topDown.empty());
-//     EXPECT_EQ(topDown.rows, 1000);
-//     EXPECT_EQ(topDown.cols, 1000);
-// }
+    // 2. Instancia a classe do projeto seguindo o namespace 'ac'
+    ac::BoardDetector detector;
 
-// // Testes para as Tasks 1.4 e 1.5: Normalização e Segmentação
-// TEST(BoardGeometryTest, TestNormalizacaoESegmentacao64Casas) {
-//     // Cria uma imagem aérea genérica de 1000x1000
-//     cv::Mat imagemTopDown(1000, 1000, CV_8UC3, cv::Scalar(0, 0, 0));
-    
-//     // Executa a Task 1.4: Normaliza para 800x800
-//     cv::Mat imagemNormalizada = normalizarImagem(imagemTopDown, 800);
-//     EXPECT_EQ(imagemNormalizada.rows, 800);
-//     EXPECT_EQ(imagemNormalizada.cols, 800);
-    
-//     // Executa a Task 1.5: Segmenta em 8x8
-//     cv::Mat board[8][8];
-//     segmentarTabuleiro(imagemNormalizada, board);
-    
-//     // Garante que o canto superior esquerdo [0][0] e o inferior direito [7][7] têm 100x100 pixels
-//     EXPECT_EQ(board[0][0].rows, 100);
-//     EXPECT_EQ(board[0][0].cols, 100);
-//     EXPECT_EQ(board[7][7].rows, 100);
-//     EXPECT_EQ(board[7][7].cols, 100);
-// }
+    // 3. Executa a detecção completa (que internamente faz a homografia e valida a geometria)
+    std::optional<ac::BoardCorners> detectedBoard = detector.detect(srcImage);
+
+    // 4. Validações do GoogleTest baseadas no retorno do código do Enzo
+    // O Enzo disse que a imagem real nao tem problemas para deteccao, entao o optional NAO pode ser nulo
+    ASSERT_TRUE(detectedBoard.has_value()) << "O algoritmo falhou em detectar o tabuleiro na imagem real.";
+
+    // Garante que os 4 cantos foram encontrados e populados no array
+    EXPECT_EQ(detectedBoard->corners.size(), 4);
+
+    // Valida se os pontos possuem coordenadas coerentes (maiores que zero)
+    for (const auto& point : detectedBoard->corners) {
+        EXPECT_GE(point.x, 0.0f);
+        EXPECT_GE(point.y, 0.0f);
+    }
+}


### PR DESCRIPTION
## Description
Refatoração completa do teste de geometria e segmentação do tabuleiro (`test_board_geometry.cpp`) para alinhar o código com as alterações recentes de arquitetura e nomenclatura inseridas no repositório.

## Changes Made
- **Nomenclatura em Inglês:** Substituição de todos os termos, variáveis e escopos para o padrão internacional do projeto (`BoardVisionTest`, `detectedBoard`, `srcImage`, etc.).
- **Integração com a Nova Arquitetura:** O teste foi adaptado para instanciar a classe oficial `ac::BoardDetector` e validar o fluxo do método `.detect()`, respeitando o encapsulamento das funções de homografia, normalização e segmentação que agora são internas da classe.
- **Uso de Imagem Real:** Substituição da matriz artificial antiga pelo carregamento real do arquivo `chessboard.png` disponibilizado na pasta de testes do repositório.

## Verification
- O arquivo foi estruturado e revisado estritamente com base na assinatura do cabeçalho `board_vision.hpp`. 
- Validações lógicas feitas via GoogleTest (`ASSERT_TRUE`, `EXPECT_EQ`, `EXPECT_GE`) garantindo o comportamento esperado do retorno do algoritmo.