### PR TITLE
feat: implementa classe StockfishUCI e comunicacao via Pipes no Linux

### DIFF
--- a/Software/acvision/CMakeLists.txt
+++ b/Software/acvision/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(acvision SHARED
     src/board_detector/board_detector.cpp
     src/piece_detector/piece_detector.cpp
     src/fen_generator/fen_generator.cpp
+    src/stockfish_uci.cpp
 )
 
 target_sources(acvision

--- a/Software/acvision/include/stockfish_uci.hpp
+++ b/Software/acvision/include/stockfish_uci.hpp
@@ -4,24 +4,59 @@
 
 namespace ac {
 
+/**
+ * @brief Class responsible for communicating with the Stockfish chess engine using the UCI protocol via Linux Pipes.
+ */
 class StockfishUCI {
 public:
+    /**
+     * @brief Constructs the Stockfish engine interface.
+     * 
+     * @param engine_path The file path to the Stockfish executable.
+     */
     StockfishUCI(const std::string& engine_path);
+    
+    /**
+     * @brief Destroys the Stockfish engine interface, ensuring the process is safely terminated.
+     */
     ~StockfishUCI();
 
+    /**
+     * @brief Initializes the engine and performs the UCI handshake.
+     * 
+     * @return true if the engine responds with "readyok", false otherwise.
+     */
     bool init();
+
+    /**
+     * @brief Calculates the best move for a given board state.
+     * 
+     * @param fen_state The current board configuration in FEN notation.
+     * @param depth The search depth for the engine (default is 15).
+     * @return std::string The best move calculated by the engine (e.g., "e2e4").
+     */
     std::string get_best_move(const std::string& fen_state, int depth = 15);
 
 private:
     std::string m_engine_path;
-    
-    
     int m_pipe_in[2];
     int m_pipe_out[2];
     pid_t m_process_id;
 
+    /**
+     * @brief Sends a string command to the Stockfish process.
+     * 
+     * @param command The UCI command to be executed.
+     */
     void send_command(const std::string& command);
+
+    /**
+     * @brief Reads the standard output from the Stockfish process until a specific stop word is found.
+     * 
+     * @param stop_word The keyword to look for in the output stream (e.g., "bestmove").
+     * @return std::string The parsed result string containing the target information.
+     */
     std::string read_output(const std::string& stop_word);
 };
 
-}
+} // namespace ac

--- a/Software/acvision/include/stockfish_uci.hpp
+++ b/Software/acvision/include/stockfish_uci.hpp
@@ -1,0 +1,27 @@
+#pragma once
+#include <string>
+#include <unistd.h>
+
+namespace ac {
+
+class StockfishUCI {
+public:
+    StockfishUCI(const std::string& engine_path);
+    ~StockfishUCI();
+
+    bool init();
+    std::string get_best_move(const std::string& fen_state, int depth = 15);
+
+private:
+    std::string m_engine_path;
+    
+    
+    int m_pipe_in[2];
+    int m_pipe_out[2];
+    pid_t m_process_id;
+
+    void send_command(const std::string& command);
+    std::string read_output(const std::string& stop_word);
+};
+
+}

--- a/Software/acvision/src/stockfish_uci.cpp
+++ b/Software/acvision/src/stockfish_uci.cpp
@@ -1,0 +1,109 @@
+#include "stockfish_uci.hpp"
+#include <iostream>
+#include <string.h>
+#include <sys/wait.h>
+
+namespace ac {
+
+StockfishUCI::StockfishUCI(const std::string& engine_path) {
+    m_engine_path = engine_path;
+    m_process_id = -1;
+}
+
+StockfishUCI::~StockfishUCI() {
+    
+    if (m_process_id != -1) {
+        send_command("quit");
+        close(m_pipe_in[1]);
+        close(m_pipe_out[0]);
+        waitpid(m_process_id, nullptr, 0); 
+    }
+}
+
+bool StockfishUCI::init() {
+    
+    if (pipe(m_pipe_in) == -1 || pipe(m_pipe_out) == -1) {
+        std::cerr << "[UCI] Erro ao criar os pipes.\n";
+        return false;
+    }
+
+    
+    m_process_id = fork();
+
+    if (m_process_id < 0) {
+        std::cerr << "[UCI] Erro no fork.\n";
+        return false;
+    }
+
+    if (m_process_id == 0) {
+        
+        dup2(m_pipe_in[0], STDIN_FILENO);
+        dup2(m_pipe_out[1], STDOUT_FILENO);
+
+        
+        close(m_pipe_in[0]); close(m_pipe_in[1]);
+        close(m_pipe_out[0]); close(m_pipe_out[1]);
+
+        
+        execlp(m_engine_path.c_str(), m_engine_path.c_str(), nullptr);
+        
+        exit(1);
+    } else {
+        
+        close(m_pipe_in[0]);
+        close(m_pipe_out[1]);
+        
+        
+        send_command("uci");
+        read_output("uciok"); 
+        
+        send_command("isready");
+        read_output("readyok"); 
+        
+        return true;
+    }
+}
+
+void StockfishUCI::send_command(const std::string& command) {
+    
+    std::string cmd = command + "\n"; 
+    write(m_pipe_in[1], cmd.c_str(), cmd.size());
+}
+
+std::string StockfishUCI::read_output(const std::string& stop_word) {
+    std::string result = "";
+    char buffer[256];
+    ssize_t bytes_read;
+
+    
+    while ((bytes_read = read(m_pipe_out[0], buffer, sizeof(buffer) - 1)) > 0) {
+        buffer[bytes_read] = '\0';
+        result += buffer;
+
+        
+        size_t pos = result.find(stop_word);
+        if (pos != std::string::npos) {
+            
+            
+            if (stop_word == "bestmove") {
+                size_t move_start = pos + 9;
+                
+                size_t move_end = result.find_first_of(" \n", move_start);
+                return result.substr(move_start, move_end - move_start); 
+            }
+            break;
+        }
+    }
+    return result;
+}
+
+std::string StockfishUCI::get_best_move(const std::string& fen_state, int depth) {
+    
+    send_command("position fen " + fen_state);
+    
+    send_command("go depth " + std::to_string(depth));
+    
+    return read_output("bestmove"); 
+}
+
+}


### PR DESCRIPTION
## 🎯 Overview
This PR implements the `StockfishUCI` class, creating a bridge between our C++ application and the Stockfish chess engine. It utilizes Linux native Inter-Process Communication (IPC) via Pipes to send UCI commands and read the engine's standard output.

Resolves #47

## 🛠️ Technical Details
* **Process Management:** Uses `fork()` and `execlp()` to clone the current process and securely boot the Stockfish executable.
* **IPC Pipes:** Implements two-way communication. Standard input (STDIN) and standard output (STDOUT) are securely duplicated using `dup2()`.
* **Resource Safety:** The class is RAII-compliant. The destructor automatically sends the "quit" command, closes open pipes, and handles `waitpid()` to prevent zombie processes.
* **String Parsing:** Custom logic to read continuous buffer output and extract the exact coordinates after the "bestmove" keyword.

## 🧪 How to Test
1. Compile the project using standard CMake build commands.
2. Ensure you have the Stockfish binary executable in your local environment.
3. Instantiate the class passing the absolute path to your Stockfish binary.
4. Call `init()` to test the handshake (should return `true`).
5. Call `get_best_move("startpos")` and verify if the engine returns a valid standard move (e.g., "e2e4").

## ⚠️ Known Issues / Difficulties
* Modifying `CMakeLists.txt` generated a minor merge conflict with `main`. The `src/stockfish_uci.cpp` file was added to the executable target list.