### PR TITLE
feat(board): implement board state updates

### DIFF
--- a/software/acchess/CMakeLists.txt
+++ b/software/acchess/CMakeLists.txt
@@ -33,6 +33,7 @@ FetchContent_MakeAvailable(SFML)
 add_library(acchess STATIC
     src/board/board.cpp
     src/board/move.cpp
+    src/board/move_applier.cpp
     src/board/piece.cpp
     src/board/square.cpp
     src/viewer/renderer.cpp
@@ -47,6 +48,7 @@ target_sources(acchess
         FILES 
             include/board/board.hpp
             include/board/move.hpp
+            include/board/move_applier.hpp
             include/board/piece.hpp
             include/board/square.hpp
             include/viewer/renderer.hpp

--- a/software/acchess/CMakeLists.txt
+++ b/software/acchess/CMakeLists.txt
@@ -17,7 +17,6 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
 set(SFML_STATIC_LIBRARIES TRUE)
-# find_package(SFML 3.0 COMPONENTS Window Graphics System REQUIRED)
 include(FetchContent)
 
 FetchContent_Declare(
@@ -27,9 +26,6 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(SFML)
 
-# ==========================================
-# TARGET: acchess (Core Library)
-# ==========================================
 add_library(acchess STATIC
     src/board/board.cpp
     src/board/move.cpp
@@ -62,9 +58,6 @@ target_include_directories(acchess
 
 target_link_libraries(acchess PUBLIC SFML::Graphics SFML::Window SFML::System)
 
-# ==========================================
-# AUTOMATIC TARGET GENERATION (Apps Folder)
-# ==========================================
 set(APP_LIST
     "chess.demo"
 )
@@ -73,10 +66,7 @@ foreach(app ${APP_LIST})
     set(app_src "apps/${app}.cpp")
     if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${app_src})
         add_executable(${app} ${app_src})
-        
-        # Linkagem Limpa: o target acchess repassa o SFML automaticamente
         target_link_libraries(${app} PRIVATE acchess)
-        
         set_target_properties(${app} PROPERTIES FOLDER "Applications")
     endif()
 endforeach()
@@ -87,16 +77,12 @@ add_custom_command(TARGET chess.demo POST_BUILD
         $<TARGET_FILE_DIR:chess.demo>/assets
 )
 
-
-# =========================================================================
-# TESTS
-# =========================================================================
-
 add_executable(test_board tests/test_board.cpp)
+add_executable(test_move_applier tests/test_move_applier.cpp)
 
-# Link the test executable with the acchess library and with Google Test.
 target_link_libraries(test_board PRIVATE acchess GTest::gtest_main)
+target_link_libraries(test_move_applier PRIVATE acchess GTest::gtest_main)
 
-# Registering tests for CTest imports automatically.
 include(GoogleTest)
 gtest_discover_tests(test_board)
+gtest_discover_tests(test_move_applier)

--- a/software/acchess/include/board/board.hpp
+++ b/software/acchess/include/board/board.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "board/piece.hpp"
-#include "board/move.hpp"
 #include "board/square.hpp"
 #include <array>
 namespace ac::chess {
@@ -17,8 +16,6 @@ class Board{
         
         Piece pieceAt(Square sq) const;
         void setPiece(Square sq, Piece piece);
-
-        void makeMove(const Move& move);
 
         bool isSqrEmpty(Square sq) const;
 

--- a/software/acchess/include/board/board.hpp
+++ b/software/acchess/include/board/board.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "board/move.hpp"
 #include "board/piece.hpp"
 #include "board/square.hpp"
 #include <array>
@@ -16,6 +17,13 @@ class Board{
         
         Piece pieceAt(Square sq) const;
         void setPiece(Square sq, Piece piece);
+
+        /**
+         * @brief Applies a move through MoveApplier.
+         * @deprecated Prefer MoveApplier::apply for new code.
+         */
+        [[deprecated("Use MoveApplier::apply")]]
+        void makeMove(const Move& move);
 
         bool isSqrEmpty(Square sq) const;
 

--- a/software/acchess/include/board/move_applier.hpp
+++ b/software/acchess/include/board/move_applier.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "board/board.hpp"
+#include "board/move.hpp"
+
+namespace ac::chess {
+
+/**
+ * @brief Applies a previously validated move to a board.
+ *
+ * This class only updates the board state. It does not decide whether a move
+ * is legal according to chess rules.
+ */
+class MoveApplier {
+public:
+    static void apply(Board& board, const Move& move);
+};
+
+} // namespace ac::chess

--- a/software/acchess/include/board/move_applier.hpp
+++ b/software/acchess/include/board/move_applier.hpp
@@ -13,7 +13,26 @@ namespace ac::chess {
  */
 class MoveApplier {
 public:
+ /** 
+  * @brief Applies a validated move to the board.
+  * @param board The board to be updated.
+  * @param move The move to be applied.
+  */
     static void apply(Board& board, const Move& move);
+
+private:
+    /**
+     * @brief Moves the rook during castling.
+     * @param board The board to be updated.
+     * @param move The castling move to be applied.
+     */
+    static void moveCastlingRook(Board& board, const Move& move);
+    /**
+     * @brief Removes the captured pawn during an en passant move.
+     * @param board The board to be updated.
+     * @param move The en passant move to be applied.
+     */
+    static void removeEnPassantPawn(Board& board, const Move& move);
 };
 
 } // namespace ac::chess

--- a/software/acchess/include/board/square.hpp
+++ b/software/acchess/include/board/square.hpp
@@ -5,5 +5,7 @@ struct Square {
     int col;
 
     bool operator==(const Square& other) const;
+
+    bool operator!=(const Square& other) const;
 };
 }

--- a/software/acchess/src/board/board.cpp
+++ b/software/acchess/src/board/board.cpp
@@ -1,4 +1,5 @@
 #include "board/board.hpp"
+#include "board/move_applier.hpp"
 #include <iostream>
 #include <cstdint>
 namespace ac::chess {
@@ -83,5 +84,10 @@ bool Board::operator==(const Board& other) const{
 
 bool Board::operator!=(const Board& other) const{
     return !(*this == other);
+}
+
+void Board::makeMove(const Move& move)
+{
+    MoveApplier::apply(*this, move);
 }
 }

--- a/software/acchess/src/board/board.cpp
+++ b/software/acchess/src/board/board.cpp
@@ -84,19 +84,4 @@ bool Board::operator==(const Board& other) const{
 bool Board::operator!=(const Board& other) const{
     return !(*this == other);
 }
-void Board::makeMove(const Move& move) {
-    // 1. Take the piece that is in the original house.
-    Piece movingPiece = pieceAt(move.from);
-
-    // 2. If it's a promotional move, update the item type.
-    if (move.promotion != PieceType::None) {
-        movingPiece.type = move.promotion;
-    }
-
-    // 3. Place the piece in its destination slot.
-    setPiece(move.to, movingPiece);
-
-    // 4. Empty the original house (by placing a 'None' piece)
-    setPiece(move.from, Piece{PieceType::None, PieceColor::None});
-}
 }

--- a/software/acchess/src/board/move_applier.cpp
+++ b/software/acchess/src/board/move_applier.cpp
@@ -2,9 +2,7 @@
 
 namespace ac::chess {
 
-namespace {
-
-void moveCastlingRook(Board& board, const Move& move)
+void MoveApplier::moveCastlingRook(Board& board, const Move& move)
 {
     const bool kingSide = move.to.col > move.from.col;
     const int rookSourceColumn = kingSide ? 7 : 0;
@@ -18,13 +16,11 @@ void moveCastlingRook(Board& board, const Move& move)
     board.setPiece(rookTarget, rook);
 }
 
-void removeEnPassantPawn(Board& board, const Move& move)
+void MoveApplier::removeEnPassantPawn(Board& board, const Move& move)
 {
     const Square capturedPawnSquare{move.from.row, move.to.col};
     board.setPiece(capturedPawnSquare, Piece{});
 }
-
-} // namespace
 
 void MoveApplier::apply(Board& board, const Move& move)
 {

--- a/software/acchess/src/board/move_applier.cpp
+++ b/software/acchess/src/board/move_applier.cpp
@@ -1,0 +1,50 @@
+#include "board/move_applier.hpp"
+
+namespace ac::chess {
+
+namespace {
+
+void moveCastlingRook(Board& board, const Move& move)
+{
+    const bool kingSide = move.to.col > move.from.col;
+    const int rookSourceColumn = kingSide ? 7 : 0;
+    const int rookTargetColumn = kingSide ? 5 : 3;
+
+    const Square rookSource{move.from.row, rookSourceColumn};
+    const Square rookTarget{move.from.row, rookTargetColumn};
+    const Piece rook = board.pieceAt(rookSource);
+
+    board.setPiece(rookSource, Piece{});
+    board.setPiece(rookTarget, rook);
+}
+
+void removeEnPassantPawn(Board& board, const Move& move)
+{
+    const Square capturedPawnSquare{move.from.row, move.to.col};
+    board.setPiece(capturedPawnSquare, Piece{});
+}
+
+} // namespace
+
+void MoveApplier::apply(Board& board, const Move& move)
+{
+    Piece movingPiece = board.pieceAt(move.from);
+
+    board.setPiece(move.from, Piece{});
+
+    if (move.enPassant) {
+        removeEnPassantPawn(board, move);
+    }
+
+    if (move.promotion != PieceType::None) {
+        movingPiece.type = move.promotion;
+    }
+
+    board.setPiece(move.to, movingPiece);
+
+    if (move.castle) {
+        moveCastlingRook(board, move);
+    }
+}
+
+} // namespace ac::chess

--- a/software/acchess/src/board/square.cpp
+++ b/software/acchess/src/board/square.cpp
@@ -6,4 +6,8 @@ bool Square::operator==(const Square& other) const {
     return row == other.row && col == other.col;
 }
 
+bool Square::operator!=(const Square& other) const {
+    return !(*this == other);
+}
+
 }

--- a/software/acchess/tests/test_move_applier.cpp
+++ b/software/acchess/tests/test_move_applier.cpp
@@ -1,0 +1,104 @@
+#include <gtest/gtest.h>
+
+#include "board/board.hpp"
+#include "board/move_applier.hpp"
+
+namespace ac::chess {
+namespace {
+
+TEST(MoveApplierTest, AppliesNormalMoveWithoutChangingOtherSquares)
+{
+    Board board;
+    board.clear();
+
+    const Square source{6, 4};
+    const Square target{4, 4};
+    const Square unchanged{2, 2};
+    const Piece pawn{PieceType::Pawn, PieceColor::White};
+    const Piece knight{PieceType::Knight, PieceColor::Black};
+
+    board.setPiece(source, pawn);
+    board.setPiece(unchanged, knight);
+
+    MoveApplier::apply(board, Move{.from = source, .to = target});
+
+    EXPECT_TRUE(board.isSqrEmpty(source));
+    EXPECT_EQ(board.pieceAt(target), pawn);
+    EXPECT_EQ(board.pieceAt(unchanged), knight);
+}
+
+TEST(MoveApplierTest, AppliesCaptureByReplacingTheTargetPiece)
+{
+    Board board;
+    board.clear();
+
+    const Square source{4, 4};
+    const Square target{3, 5};
+    const Piece whitePawn{PieceType::Pawn, PieceColor::White};
+
+    board.setPiece(source, whitePawn);
+    board.setPiece(target, {PieceType::Pawn, PieceColor::Black});
+
+    MoveApplier::apply(board, Move{.from = source, .to = target, .capture = true});
+
+    EXPECT_TRUE(board.isSqrEmpty(source));
+    EXPECT_EQ(board.pieceAt(target), whitePawn);
+}
+
+TEST(MoveApplierTest, AppliesPromotionAndPreservesPieceColor)
+{
+    Board board;
+    board.clear();
+    board.setPiece({1, 0}, {PieceType::Pawn, PieceColor::White});
+
+    MoveApplier::apply(board, Move{.from = {1, 0}, .to = {0, 0}, .promotion = PieceType::Queen});
+
+    EXPECT_EQ(board.pieceAt({0, 0}), (Piece{PieceType::Queen, PieceColor::White}));
+}
+
+TEST(MoveApplierTest, AppliesKingSideCastling)
+{
+    Board board;
+    board.clear();
+    board.setPiece({7, 4}, {PieceType::King, PieceColor::White});
+    board.setPiece({7, 7}, {PieceType::Rook, PieceColor::White});
+
+    MoveApplier::apply(board, Move{.from = {7, 4}, .to = {7, 6}, .castle = true});
+
+    EXPECT_TRUE(board.isSqrEmpty({7, 4}));
+    EXPECT_TRUE(board.isSqrEmpty({7, 7}));
+    EXPECT_EQ(board.pieceAt({7, 6}), (Piece{PieceType::King, PieceColor::White}));
+    EXPECT_EQ(board.pieceAt({7, 5}), (Piece{PieceType::Rook, PieceColor::White}));
+}
+
+TEST(MoveApplierTest, AppliesQueenSideCastling)
+{
+    Board board;
+    board.clear();
+    board.setPiece({0, 4}, {PieceType::King, PieceColor::Black});
+    board.setPiece({0, 0}, {PieceType::Rook, PieceColor::Black});
+
+    MoveApplier::apply(board, Move{.from = {0, 4}, .to = {0, 2}, .castle = true});
+
+    EXPECT_TRUE(board.isSqrEmpty({0, 4}));
+    EXPECT_TRUE(board.isSqrEmpty({0, 0}));
+    EXPECT_EQ(board.pieceAt({0, 2}), (Piece{PieceType::King, PieceColor::Black}));
+    EXPECT_EQ(board.pieceAt({0, 3}), (Piece{PieceType::Rook, PieceColor::Black}));
+}
+
+TEST(MoveApplierTest, AppliesEnPassantCapture)
+{
+    Board board;
+    board.clear();
+    board.setPiece({3, 4}, {PieceType::Pawn, PieceColor::White});
+    board.setPiece({3, 5}, {PieceType::Pawn, PieceColor::Black});
+
+    MoveApplier::apply(board, Move{.from = {3, 4}, .to = {2, 5}, .capture = true, .enPassant = true});
+
+    EXPECT_TRUE(board.isSqrEmpty({3, 4}));
+    EXPECT_TRUE(board.isSqrEmpty({3, 5}));
+    EXPECT_EQ(board.pieceAt({2, 5}), (Piece{PieceType::Pawn, PieceColor::White}));
+}
+
+} // namespace
+} // namespace ac::chess

--- a/software/acchess/tests/test_move_applier.cpp
+++ b/software/acchess/tests/test_move_applier.cpp
@@ -2,6 +2,7 @@
 
 #include "board/board.hpp"
 #include "board/move_applier.hpp"
+#include <cstdint>
 
 namespace ac::chess {
 namespace {
@@ -13,18 +14,24 @@ TEST(MoveApplierTest, AppliesNormalMoveWithoutChangingOtherSquares)
 
     const Square source{6, 4};
     const Square target{4, 4};
-    const Square unchanged{2, 2};
     const Piece pawn{PieceType::Pawn, PieceColor::White};
     const Piece knight{PieceType::Knight, PieceColor::Black};
 
     board.setPiece(source, pawn);
-    board.setPiece(unchanged, knight);
 
     MoveApplier::apply(board, Move{.from = source, .to = target});
 
     EXPECT_TRUE(board.isSqrEmpty(source));
     EXPECT_EQ(board.pieceAt(target), pawn);
-    EXPECT_EQ(board.pieceAt(unchanged), knight);
+
+    for (uint8_t row = 0; row< 8; ++row){
+        for (uint8_t col = 0; col < 8; ++col){
+            Square sq{row, col};
+            if (sq != source && sq != target){
+                EXPECT_TRUE(board.isSqrEmpty(sq));
+            }
+        }
+    }
 }
 
 TEST(MoveApplierTest, AppliesCaptureByReplacingTheTargetPiece)


### PR DESCRIPTION
## Context

Implements issue #61 by centralizing board state updates in a dedicated `MoveApplier` component.

## Changes

- adds `MoveApplier::apply(Board&, const Move&)`;
- supports normal moves and captures;
- supports promotion while preserving piece color;
- supports kingside and queenside castling;
- supports en passant;
- keeps the movement logic outside the `Board` data structure;
- keeps the existing `Board::makeMove()` API as a deprecated compatibility wrapper that delegates to `MoveApplier`;
- adds focused GoogleTest coverage for all supported update scenarios.

## Validation

The implementation was compiled locally with C++20 and strict warning flags during preparation. The repository CI should run the complete CMake/GoogleTest suite for the published branch.

Closes #61