### PR TITLE
feat(board): implement board state comparison

### DIFF
--- a/software/acchess/CMakeLists.txt
+++ b/software/acchess/CMakeLists.txt
@@ -17,7 +17,6 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
 set(SFML_STATIC_LIBRARIES TRUE)
-# find_package(SFML 3.0 COMPONENTS Window Graphics System REQUIRED)
 include(FetchContent)
 
 FetchContent_Declare(
@@ -27,11 +26,9 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(SFML)
 
-# ==========================================
-# TARGET: acchess (Core Library)
-# ==========================================
 add_library(acchess STATIC
     src/board/board.cpp
+    src/board/board_comparator.cpp
     src/board/move.cpp
     src/board/piece.cpp
     src/board/square.cpp
@@ -46,9 +43,11 @@ target_sources(acchess
         BASE_DIRS include
         FILES 
             include/board/board.hpp
+            include/board/board_comparator.hpp
             include/board/move.hpp
             include/board/piece.hpp
             include/board/square.hpp
+            include/board/square_change.hpp
             include/viewer/renderer.hpp
             include/utils/path.hpp
 )
@@ -60,9 +59,6 @@ target_include_directories(acchess
 
 target_link_libraries(acchess PUBLIC SFML::Graphics SFML::Window SFML::System)
 
-# ==========================================
-# AUTOMATIC TARGET GENERATION (Apps Folder)
-# ==========================================
 set(APP_LIST
     "chess.demo"
 )
@@ -71,10 +67,7 @@ foreach(app ${APP_LIST})
     set(app_src "apps/${app}.cpp")
     if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${app_src})
         add_executable(${app} ${app_src})
-        
-        # Linkagem Limpa: o target acchess repassa o SFML automaticamente
         target_link_libraries(${app} PRIVATE acchess)
-        
         set_target_properties(${app} PROPERTIES FOLDER "Applications")
     endif()
 endforeach()
@@ -85,16 +78,12 @@ add_custom_command(TARGET chess.demo POST_BUILD
         $<TARGET_FILE_DIR:chess.demo>/assets
 )
 
-
-# =========================================================================
-# TESTS
-# =========================================================================
-
 add_executable(test_board tests/test_board.cpp)
+add_executable(test_board_comparator tests/test_board_comparator.cpp)
 
-# Link the test executable with the acchess library and with Google Test.
 target_link_libraries(test_board PRIVATE acchess GTest::gtest_main)
+target_link_libraries(test_board_comparator PRIVATE acchess GTest::gtest_main)
 
-# Registering tests for CTest imports automatically.
 include(GoogleTest)
 gtest_discover_tests(test_board)
+gtest_discover_tests(test_board_comparator)

--- a/software/acchess/include/board/board_comparator.hpp
+++ b/software/acchess/include/board/board_comparator.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "board/board.hpp"
+#include "board/square_change.hpp"
+
+#include <vector>
+
+namespace ac::chess {
+
+/**
+ * @brief Compares board states without interpreting chess moves.
+ */
+class BoardComparator {
+public:
+    /**
+     * @return All changed squares in row-major order.
+     */
+    [[nodiscard]] static std::vector<SquareChange> compare(
+        const Board& previous,
+        const Board& current
+    );
+};
+
+} // namespace ac::chess

--- a/software/acchess/include/board/board_comparator.hpp
+++ b/software/acchess/include/board/board_comparator.hpp
@@ -14,6 +14,7 @@ class BoardComparator {
 public:
     /**
      * @return All changed squares in row-major order.
+     * @note The [[nodiscard]] attribute is used to indicate that the return value of this function is the main purpose of the function, thus should not be ignored.
      */
     [[nodiscard]] static std::vector<SquareChange> compare(
         const Board& previous,

--- a/software/acchess/include/board/square_change.hpp
+++ b/software/acchess/include/board/square_change.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "board/piece.hpp"
+#include "board/square.hpp"
+
+namespace ac::chess {
+
+/**
+ * @brief Describes how one square changed between two board states.
+ */
+struct SquareChange {
+    Square square;
+    Piece before;
+    Piece after;
+
+    bool operator==(const SquareChange&) const = default;
+};
+
+} // namespace ac::chess

--- a/software/acchess/src/board/board_comparator.cpp
+++ b/software/acchess/src/board/board_comparator.cpp
@@ -8,7 +8,7 @@ std::vector<SquareChange> BoardComparator::compare(
 )
 {
     std::vector<SquareChange> changes;
-    changes.reserve(4);
+    changes.reserve(4); // the number 4 here is chosen because the max number of squares that can change in a single chess move is 4 (castling).
 
     for (int row = 0; row < 8; ++row) {
         for (int col = 0; col < 8; ++col) {

--- a/software/acchess/src/board/board_comparator.cpp
+++ b/software/acchess/src/board/board_comparator.cpp
@@ -1,0 +1,28 @@
+#include "board/board_comparator.hpp"
+
+namespace ac::chess {
+
+std::vector<SquareChange> BoardComparator::compare(
+    const Board& previous,
+    const Board& current
+)
+{
+    std::vector<SquareChange> changes;
+    changes.reserve(4);
+
+    for (int row = 0; row < 8; ++row) {
+        for (int col = 0; col < 8; ++col) {
+            const Square square{row, col};
+            const Piece before = previous.pieceAt(square);
+            const Piece after = current.pieceAt(square);
+
+            if (!(before == after)) {
+                changes.push_back({square, before, after});
+            }
+        }
+    }
+
+    return changes;
+}
+
+} // namespace ac::chess

--- a/software/acchess/src/board/board_comparator.cpp
+++ b/software/acchess/src/board/board_comparator.cpp
@@ -1,4 +1,5 @@
 #include "board/board_comparator.hpp"
+#include <cstdint>
 
 namespace ac::chess {
 
@@ -10,8 +11,8 @@ std::vector<SquareChange> BoardComparator::compare(
     std::vector<SquareChange> changes;
     changes.reserve(4); // the number 4 here is chosen because the max number of squares that can change in a single chess move is 4 (castling).
 
-    for (int row = 0; row < 8; ++row) {
-        for (int col = 0; col < 8; ++col) {
+    for (uint8_t row = 0; row < 8; ++row) {
+        for (uint8_t col = 0; col < 8; ++col) {
             const Square square{row, col};
             const Piece before = previous.pieceAt(square);
             const Piece after = current.pieceAt(square);

--- a/software/acchess/tests/test_board_comparator.cpp
+++ b/software/acchess/tests/test_board_comparator.cpp
@@ -1,0 +1,123 @@
+#include <gtest/gtest.h>
+
+#include "board/board.hpp"
+#include "board/board_comparator.hpp"
+
+namespace ac::chess {
+namespace {
+
+TEST(BoardComparatorTest, ReturnsNoChangesForEqualBoards)
+{
+    Board previous;
+    Board current;
+
+    EXPECT_TRUE(BoardComparator::compare(previous, current).empty());
+}
+
+TEST(BoardComparatorTest, ReportsSimpleMoveInRowMajorOrder)
+{
+    Board previous;
+    previous.clear();
+    previous.setPiece({1, 4}, {PieceType::Pawn, PieceColor::White});
+
+    Board current = previous;
+    current.setPiece({1, 4}, Piece{});
+    current.setPiece({3, 4}, {PieceType::Pawn, PieceColor::White});
+
+    const auto changes = BoardComparator::compare(previous, current);
+
+    ASSERT_EQ(changes.size(), 2);
+    EXPECT_EQ(changes[0], (SquareChange{.square = {1, 4}, .before = {PieceType::Pawn, PieceColor::White}, .after = {}}));
+    EXPECT_EQ(changes[1], (SquareChange{.square = {3, 4}, .before = {}, .after = {PieceType::Pawn, PieceColor::White}}));
+}
+
+TEST(BoardComparatorTest, ReportsCaptureWithPreviousAndCurrentPieces)
+{
+    Board previous;
+    previous.clear();
+    previous.setPiece({4, 4}, {PieceType::Pawn, PieceColor::White});
+    previous.setPiece({3, 5}, {PieceType::Pawn, PieceColor::Black});
+
+    Board current = previous;
+    current.setPiece({4, 4}, Piece{});
+    current.setPiece({3, 5}, {PieceType::Pawn, PieceColor::White});
+
+    const auto changes = BoardComparator::compare(previous, current);
+
+    ASSERT_EQ(changes.size(), 2);
+    EXPECT_EQ(changes[0].square, (Square{3, 5}));
+    EXPECT_EQ(changes[0].before, (Piece{PieceType::Pawn, PieceColor::Black}));
+    EXPECT_EQ(changes[0].after, (Piece{PieceType::Pawn, PieceColor::White}));
+}
+
+TEST(BoardComparatorTest, ReportsPromotionAsTwoChangedSquares)
+{
+    Board previous;
+    previous.clear();
+    previous.setPiece({1, 0}, {PieceType::Pawn, PieceColor::White});
+
+    Board current = previous;
+    current.setPiece({1, 0}, Piece{});
+    current.setPiece({0, 0}, {PieceType::Queen, PieceColor::White});
+
+    const auto changes = BoardComparator::compare(previous, current);
+
+    ASSERT_EQ(changes.size(), 2);
+    EXPECT_EQ(changes[0].square, (Square{0, 0}));
+    EXPECT_EQ(changes[0].after, (Piece{PieceType::Queen, PieceColor::White}));
+}
+
+TEST(BoardComparatorTest, ReportsFourChangedSquaresForCastling)
+{
+    Board previous;
+    previous.clear();
+    previous.setPiece({7, 4}, {PieceType::King, PieceColor::White});
+    previous.setPiece({7, 7}, {PieceType::Rook, PieceColor::White});
+
+    Board current = previous;
+    current.setPiece({7, 4}, Piece{});
+    current.setPiece({7, 7}, Piece{});
+    current.setPiece({7, 6}, {PieceType::King, PieceColor::White});
+    current.setPiece({7, 5}, {PieceType::Rook, PieceColor::White});
+
+    EXPECT_EQ(BoardComparator::compare(previous, current).size(), 4);
+}
+
+TEST(BoardComparatorTest, ReportsThreeChangedSquaresForEnPassant)
+{
+    Board previous;
+    previous.clear();
+    previous.setPiece({3, 4}, {PieceType::Pawn, PieceColor::White});
+    previous.setPiece({3, 5}, {PieceType::Pawn, PieceColor::Black});
+
+    Board current = previous;
+    current.setPiece({3, 4}, Piece{});
+    current.setPiece({3, 5}, Piece{});
+    current.setPiece({2, 5}, {PieceType::Pawn, PieceColor::White});
+
+    EXPECT_EQ(BoardComparator::compare(previous, current).size(), 3);
+}
+
+TEST(BoardComparatorTest, ReportsAllChangedSquaresWithoutInterpretingThem)
+{
+    Board previous;
+    previous.clear();
+
+    Board current;
+    current.clear();
+
+    for (int row = 0; row < 8; ++row) {
+        for (int col = 0; col < 8; ++col) {
+            current.setPiece({row, col}, {PieceType::Pawn, PieceColor::White});
+        }
+    }
+
+    const auto changes = BoardComparator::compare(previous, current);
+
+    ASSERT_EQ(changes.size(), 64);
+    EXPECT_EQ(changes.front().square, (Square{0, 0}));
+    EXPECT_EQ(changes.back().square, (Square{7, 7}));
+}
+
+} // namespace
+} // namespace ac::chess

--- a/software/acchess/tests/test_board_comparator.cpp
+++ b/software/acchess/tests/test_board_comparator.cpp
@@ -2,6 +2,7 @@
 
 #include "board/board.hpp"
 #include "board/board_comparator.hpp"
+#include <cstdint>
 
 namespace ac::chess {
 namespace {
@@ -27,8 +28,21 @@ TEST(BoardComparatorTest, ReportsSimpleMoveInRowMajorOrder)
     const auto changes = BoardComparator::compare(previous, current);
 
     ASSERT_EQ(changes.size(), 2);
-    EXPECT_EQ(changes[0], (SquareChange{.square = {1, 4}, .before = {PieceType::Pawn, PieceColor::White}, .after = {}}));
-    EXPECT_EQ(changes[1], (SquareChange{.square = {3, 4}, .before = {}, .after = {PieceType::Pawn, PieceColor::White}}));
+    EXPECT_EQ(
+        changes[0], 
+        (SquareChange{
+            .square = {1, 4}, 
+            .before = {PieceType::Pawn, PieceColor::White}, 
+            .after = {}
+        }));
+    
+    EXPECT_EQ(
+        changes[1], 
+        (SquareChange{
+            .square = {3, 4}, 
+            .before = {}, 
+            .after = {PieceType::Pawn, PieceColor::White}
+        }));
 }
 
 TEST(BoardComparatorTest, ReportsCaptureWithPreviousAndCurrentPieces)
@@ -76,8 +90,8 @@ TEST(BoardComparatorTest, ReportsFourChangedSquaresForCastling)
 
     Board current = previous;
     current.setPiece({7, 4}, Piece{});
-    current.setPiece({7, 7}, Piece{});
     current.setPiece({7, 6}, {PieceType::King, PieceColor::White});
+    current.setPiece({7, 7}, Piece{});
     current.setPiece({7, 5}, {PieceType::Rook, PieceColor::White});
 
     EXPECT_EQ(BoardComparator::compare(previous, current).size(), 4);
@@ -106,8 +120,8 @@ TEST(BoardComparatorTest, ReportsAllChangedSquaresWithoutInterpretingThem)
     Board current;
     current.clear();
 
-    for (int row = 0; row < 8; ++row) {
-        for (int col = 0; col < 8; ++col) {
+    for (uint8_t row = 0; row < 8; ++row) {
+        for (uint8_t col = 0; col < 8; ++col) {
             current.setPiece({row, col}, {PieceType::Pawn, PieceColor::White});
         }
     }


### PR DESCRIPTION
## Context

Implements issue #62 by comparing two board states at square level without interpreting chess rules.

## Changes

- adds `SquareChange` with square, previous piece and current piece;
- adds `BoardComparator::compare`;
- compares all 64 squares in deterministic row-major order;
- reports normal moves, captures, promotions, castling and en passant as raw square changes;
- keeps semantic movement interpretation outside the comparator;
- adds focused GoogleTest coverage for equal boards and all relevant change patterns.

## Validation

The implementation was compiled locally with C++20 and strict warning flags during preparation. The repository CI should run the complete CMake/GoogleTest suite for the published branch.

Closes #62