### PR TITLE
fix(acchess): add error handling for Stockfish IPC initialization

### DIFF
--- a/software/acchess/src/engine/stockfish_uci.cpp
+++ b/software/acchess/src/engine/stockfish_uci.cpp
@@ -50,10 +50,16 @@ bool StockfishUCI::init() {
         close(m_pipe_out[1]);
         
         send_command("uci");
-        read_output("uciok"); 
+        if (read_output("uciok").empty()) {
+            std::cerr << "[UCI] Erro: Falha ao inicializar o protocolo UCI ou timeout atingido.\n";
+            return false;
+        }
         
         send_command("isready");
-        read_output("readyok"); 
+        if (read_output("readyok").empty()) {
+            std::cerr << "[UCI] Erro: Motor nao esta pronto ou timeout atingido.\n";
+            return false;
+        }
         
         return true;
     }


### PR DESCRIPTION
## Description
This PR addresses an issue where the system would silently fail and continue execution if the Stockfish engine timed out or failed to respond during initialization.

## Changes Made
* Added guard clauses to the `init()` method in `stockfish_uci.cpp`.
* Implemented checks to verify if `read_output()` returns an empty string after sending the `uci` and `isready` commands.
* The method now correctly returns `false` and logs an error if the engine fails to respond, preventing unexpected behavior in the main application.

Closes #101