### PR TITLE
fix(cmake): wire tests into CTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,5 +2,7 @@ cmake_minimum_required(VERSION 3.23)
 
 project(ATOMChess)
 
+include(CTest)
+
 add_subdirectory(software/acvision)
 add_subdirectory(software/acchess)

--- a/software/acchess/CMakeLists.txt
+++ b/software/acchess/CMakeLists.txt
@@ -118,6 +118,9 @@ if(BUILD_TESTING AND STOCKFISH_EXECUTABLE)
 
     add_executable(test_stockfish_uci tests/test_stockfish_uci.cpp)
     target_link_libraries(test_stockfish_uci PRIVATE acchess GTest::gtest_main)
+    target_compile_definitions(test_stockfish_uci PRIVATE
+        STOCKFISH_EXECUTABLE_PATH="${STOCKFISH_EXECUTABLE}"
+    )
     add_test(NAME test_stockfish_uci COMMAND test_stockfish_uci)
     set_target_properties(test_stockfish_uci PROPERTIES FOLDER "Tests")
 endif()

--- a/software/acchess/CMakeLists.txt
+++ b/software/acchess/CMakeLists.txt
@@ -5,6 +5,10 @@ project(acchess
     DESCRIPTION "A Library for Chess"
     LANGUAGES CXX)
 
+if(PROJECT_IS_TOP_LEVEL)
+    include(CTest)
+endif()
+
 # ==========================================
 # Configurações Globais
 # ==========================================
@@ -25,16 +29,19 @@ if(NOT STOCKFISH_EXECUTABLE)
     message(WARNING "Stockfish executable not found! Make sure it is installed via apt.")
 endif()
 
-set(SFML_STATIC_LIBRARIES TRUE)
-# find_package(SFML 3.0 COMPONENTS Window Graphics System REQUIRED)
-include(FetchContent)
+option(ACCHESS_BUILD_VIEWER "Build the SFML viewer and demo application" ON)
 
-FetchContent_Declare(
-    SFML
-    GIT_REPOSITORY https://github.com/SFML/SFML.git
-    GIT_TAG        3.0.0
-)
-FetchContent_MakeAvailable(SFML)
+if(ACCHESS_BUILD_VIEWER)
+    set(SFML_STATIC_LIBRARIES TRUE)
+    include(FetchContent)
+
+    FetchContent_Declare(
+        SFML
+        GIT_REPOSITORY https://github.com/SFML/SFML.git
+        GIT_TAG        3.0.0
+    )
+    FetchContent_MakeAvailable(SFML)
+endif()
 
 # ==========================================
 # TARGET: acchess (Core Library)
@@ -44,7 +51,6 @@ add_library(acchess STATIC
     src/board/move.cpp
     src/board/piece.cpp
     src/board/square.cpp
-    src/viewer/renderer.cpp
     src/utils/path.cpp
     src/engine/stockfish_uci.cpp
 )
@@ -58,7 +64,6 @@ target_sources(acchess
             include/board/move.hpp
             include/board/piece.hpp
             include/board/square.hpp
-            include/viewer/renderer.hpp
             include/utils/path.hpp
             include/engine/stockfish_uci.hpp
 )
@@ -68,65 +73,51 @@ target_include_directories(acchess
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
-target_link_libraries(acchess PUBLIC SFML::Graphics SFML::Window SFML::System)
+if(ACCHESS_BUILD_VIEWER)
+    target_sources(acchess
+        PRIVATE
+            src/viewer/renderer.cpp
+        PUBLIC
+            FILE_SET HEADERS
+            BASE_DIRS include
+            FILES include/viewer/renderer.hpp
+    )
+    target_link_libraries(acchess PUBLIC SFML::Graphics SFML::Window SFML::System)
 
-# ==========================================
-# AUTOMATIC TARGET GENERATION (Apps Folder)
-# ==========================================
-set(APP_LIST
-    "chess.demo"
-)
+    add_executable(chess.demo apps/chess.demo.cpp)
+    target_link_libraries(chess.demo PRIVATE acchess)
+    set_target_properties(chess.demo PROPERTIES FOLDER "Applications")
 
-foreach(app ${APP_LIST})
-    set(app_src "apps/${app}.cpp")
-    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${app_src})
-        add_executable(${app} ${app_src})
-        
-        # Linkagem Limpa: o target acchess repassa o SFML automaticamente
-        target_link_libraries(${app} PRIVATE acchess)
-        
-        set_target_properties(${app} PROPERTIES FOLDER "Applications")
-    endif()
-endforeach()
-
-add_custom_command(TARGET chess.demo POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${CMAKE_CURRENT_SOURCE_DIR}/assets
-        $<TARGET_FILE_DIR:chess.demo>/assets
-)
+    add_custom_command(TARGET chess.demo POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_CURRENT_SOURCE_DIR}/assets
+            $<TARGET_FILE_DIR:chess.demo>/assets
+    )
+endif()
 
 # ==========================================
 # AUTOMATED TESTS (tests Folder)
 # ==========================================
-enable_testing()
+if(BUILD_TESTING AND STOCKFISH_EXECUTABLE)
+    include(FetchContent)
 
-# Download Google Test
-FetchContent_Declare(
-  googletest
-  GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG        v1.14.0
-)
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
-
-set(TEST_LIST
-    "test_stockfish_uci"
-    
-)
-
-foreach(test_name ${TEST_LIST})
-    set(test_src "tests/${test_name}.cpp")
-    
-    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${test_src})
-        add_executable(${test_name} ${test_src})
-        
-        target_link_libraries(${test_name} 
-            PRIVATE 
-                acchess 
-                GTest::gtest_main
-        )
-        
-        add_test(NAME ${test_name} COMMAND ${test_name})
-        set_target_properties(${test_name} PROPERTIES FOLDER "Tests")
+    if(NOT TARGET GTest::gtest_main)
+        find_package(GTest QUIET)
     endif()
-endforeach()
+
+    if(NOT TARGET GTest::gtest_main)
+        FetchContent_Declare(
+            googletest
+            GIT_REPOSITORY https://github.com/google/googletest.git
+            GIT_TAG v1.14.0
+            GIT_SHALLOW TRUE
+        )
+        set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+        FetchContent_MakeAvailable(googletest)
+    endif()
+
+    add_executable(test_stockfish_uci tests/test_stockfish_uci.cpp)
+    target_link_libraries(test_stockfish_uci PRIVATE acchess GTest::gtest_main)
+    add_test(NAME test_stockfish_uci COMMAND test_stockfish_uci)
+    set_target_properties(test_stockfish_uci PROPERTIES FOLDER "Tests")
+endif()

--- a/software/acchess/tests/test_stockfish_uci.cpp
+++ b/software/acchess/tests/test_stockfish_uci.cpp
@@ -2,13 +2,13 @@
 #include "engine/stockfish_uci.hpp" 
 
 TEST(StockfishUCITest, Inicializacao) {
-    ac::chess::engine::StockfishUCI stockfish("stockfish");
+    ac::chess::engine::StockfishUCI stockfish(STOCKFISH_EXECUTABLE_PATH);
     bool iniciou = stockfish.init();
     EXPECT_TRUE(iniciou); 
 }
 
 TEST(StockfishUCITest, RetornaMelhorJogada) {
-    ac::chess::engine::StockfishUCI stockfish("stockfish");
+    ac::chess::engine::StockfishUCI stockfish(STOCKFISH_EXECUTABLE_PATH);
     stockfish.init();
     
     std::string fen_inicial = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
@@ -19,7 +19,7 @@ TEST(StockfishUCITest, RetornaMelhorJogada) {
 }
 
 TEST(StockfishUCITest, BestMoveIsCheckMate){
-    ac::chess::engine::StockfishUCI stockfish("stockfish");
+    ac::chess::engine::StockfishUCI stockfish(STOCKFISH_EXECUTABLE_PATH);
     stockfish.init();
 
     std::string fen = "6k1/5ppp/8/8/8/5Q2/6PP/6K1 w - - 0 1";

--- a/software/acvision/CMakeLists.txt
+++ b/software/acvision/CMakeLists.txt
@@ -187,8 +187,8 @@ if(BUILD_TESTING)
     endforeach()
 
     target_link_libraries(test_board_geometry PRIVATE opencv_imgcodecs)
-    set_tests_properties(test_board_geometry PROPERTIES
-        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../.."
+    target_compile_definitions(test_board_geometry PRIVATE
+        TEST_IMAGES_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests/images"
     )
 endif()
 

--- a/software/acvision/CMakeLists.txt
+++ b/software/acvision/CMakeLists.txt
@@ -7,6 +7,10 @@ project(acvision
     DESCRIPTION "A Library for Computer Vision applied to Chessboard Analysis"
     LANGUAGES CXX)
 
+if(PROJECT_IS_TOP_LEVEL)
+    include(CTest)
+endif()
+
 # ==========================================
 # Configurações Globais (Modern C++)
 # ==========================================
@@ -132,64 +136,61 @@ endforeach()
 # ==========================================
 # AUTOMATED TESTS (tests Folder)
 # ==========================================
-enable_testing()
+if(BUILD_TESTING)
+    include(FetchContent)
 
-# 1. Faz o download automático do Google Test (Padrão Sênior)
-include(FetchContent)
-FetchContent_Declare(
-  googletest
-  GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG        v1.14.0 # Versão estável
-)
-# Força o GTest a usar o mesmo C-Runtime (CRT) dinâmico do MSVC no Windows
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
+    if(NOT TARGET GTest::gtest_main)
+        find_package(GTest QUIET)
+    endif()
 
-set(TEST_LIST
-    "test_camera"
-    "test_piece_detector"
-    "test_board_geometry"
-    
-)
-
-foreach(test_name ${TEST_LIST})
-    set(test_src "tests/${test_name}.cpp")
-    
-    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${test_src})
-        add_executable(${test_name} ${test_src})
-        
-        target_link_libraries(${test_name} 
-            PRIVATE 
-                acvision 
-                GTest::gtest_main
+    if(NOT TARGET GTest::gtest_main)
+        FetchContent_Declare(
+            googletest
+            GIT_REPOSITORY https://github.com/google/googletest.git
+            GIT_TAG v1.14.0
+            GIT_SHALLOW TRUE
         )
+        set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+        FetchContent_MakeAvailable(googletest)
+    endif()
 
-        if("${test_name}" STREQUAL "test_board_detector")
-            target_link_libraries(${test_name}
-                PRIVATE
-                    opencv_imgcodecs
-            )
+    set(TEST_LIST
+        test_piece_detector
+        test_board_geometry
+    )
 
-            target_compile_definitions(${test_name}
-                PRIVATE
-                    TEST_IMAGES_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests/images"
-            )
-        endif()
-        
+    option(
+        ACVISION_BUILD_HARDWARE_TESTS
+        "Build tests that require a physical camera"
+        OFF
+    )
+
+    if(ACVISION_BUILD_HARDWARE_TESTS)
+        list(APPEND TEST_LIST test_camera)
+    endif()
+
+    foreach(test_name ${TEST_LIST})
+        add_executable(${test_name} tests/${test_name}.cpp)
+        target_link_libraries(${test_name} PRIVATE acvision GTest::gtest_main)
         add_test(NAME ${test_name} COMMAND ${test_name})
         set_target_properties(${test_name} PROPERTIES FOLDER "Tests")
-        
+
         if(WIN32)
             add_custom_command(TARGET ${test_name} POST_BUILD
                 COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                $<TARGET_RUNTIME_DLLS:${test_name}>
-                $<TARGET_FILE_DIR:${test_name}>
+                    $<TARGET_RUNTIME_DLLS:${test_name}>
+                    $<TARGET_FILE_DIR:${test_name}>
                 COMMAND_EXPAND_LISTS
                 COMMENT "[ACVISION] Copying OpenCV DLLs for test: ${test_name}"
             )
         endif()
-    endif()
-endforeach()
+    endforeach()
+
+    target_link_libraries(test_board_geometry PRIVATE opencv_imgcodecs)
+    set_tests_properties(test_board_geometry PROPERTIES
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../.."
+    )
+endif()
 
 # ==========================================
 # Configuração de IDE

--- a/software/acvision/tests/test_board_geometry.cpp
+++ b/software/acvision/tests/test_board_geometry.cpp
@@ -1,14 +1,18 @@
 #include <gtest/gtest.h>
 #include <opencv2/opencv.hpp>
-#include <string>
+#include <filesystem>
 #include <optional>
 #include "board_vision/board_vision.hpp"
+
+#ifndef TEST_IMAGES_DIR
+#define TEST_IMAGES_DIR "."
+#endif
 
 // Teste focado no fluxo real que o Enzo implementou
 TEST(BoardVisionTest, TestRealBoardDetectionAndGeometry) {
     // 1. Carrega a imagem real que o Enzo disponibilizou
-    std::string imagePath = "software/acvision/tests/images/chessboard.png";
-    cv::Mat srcImage = cv::imread(imagePath);
+    const auto imagePath = std::filesystem::path(TEST_IMAGES_DIR) / "chessboard.png";
+    cv::Mat srcImage = cv::imread(imagePath.string());
     
     // Garante que o arquivo de imagem foi aberto com sucesso
     ASSERT_FALSE(srcImage.empty()) << "Erro: Nao foi possivel carregar a imagem de teste em: " << imagePath;

--- a/software/docs/adrs/ADR-001-cmake-ctest-integration.md
+++ b/software/docs/adrs/ADR-001-cmake-ctest-integration.md
@@ -1,0 +1,23 @@
+# ADR-001: CMake and CTest integration
+
+## Problem
+
+Tests were defined inside individual modules, but CTest was not enabled at the
+repository root. Hardware and graphical dependencies also made the default test
+build unreliable on headless machines.
+
+## Decision
+
+Enable CTest from the root and when a module is configured on its own. Build the
+deterministic vision tests by default, keep the camera test opt-in, and register
+the Stockfish test only when Stockfish is installed. Use an installed GoogleTest
+package when available, with v1.14.0 as the download fallback.
+
+The SFML viewer remains enabled by default and can be disabled with
+`ACCHESS_BUILD_VIEWER=OFF` for headless test builds.
+
+## Consequences
+
+`BUILD_TESTING=OFF` excludes test dependencies and targets. Root and standalone
+builds expose their registered tests through CTest without requiring camera or
+display hardware.


### PR DESCRIPTION
## Summary

Wire the existing deterministic tests into the root and standalone CMake builds. Keep hardware and graphical dependencies optional so headless builds can test the core modules.

## Changes

* enable CTest from the repository root and standalone modules;
* make camera tests opt-in and register Stockfish tests only when Stockfish is available;
* pass the detected Stockfish path to its test binary;
* allow the SFML viewer to be disabled for headless builds;
* resolve test asset paths independently of the working directory;
* document the build decision in a short ADR.

## Testing

* root headless build and CTest: 2 tests passed;
* standalone acvision build and CTest: 2 tests passed;
* standalone acchess headless build: passed;
* Stockfish test target compiled with an explicit executable path;
* root headless build with `BUILD_TESTING=OFF`: passed;
* board geometry test executed successfully from `/tmp`.

## Related

Closes #24