### PR TITLE
feat(acmotion): implement 2x8 graveyard matrices and unit tests

### DIFF
--- a/software/acmotion/include/motion/motion_planner.hpp
+++ b/software/acmotion/include/motion/motion_planner.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 #include <utility>
+#include <cstddef>
 
 /**
  * @file motion_planner.hpp
@@ -18,8 +19,19 @@ namespace ac::motion {
  */
 enum class PredefinedPosition {
     HOME,
-    GRAVEYARD,
+    GRAVEYARD,         ///< Legacy generic graveyard position
+    GRAVEYARD_WHITE,   ///< Base position for white pieces 2x8 graveyard matrix
+    GRAVEYARD_BLACK,   ///< Base position for black pieces 2x8 graveyard matrix
     SAFE_STAGING
+};
+
+/**
+ * @enum PieceColor
+ * @brief Represents the color of a chess piece for graveyard matrix indexing.
+ */
+enum class PieceColor {
+    WHITE,
+    BLACK
 };
 
 /**
@@ -27,11 +39,11 @@ enum class PredefinedPosition {
  * @brief Represents a 3D Cartesian position, gripper aperture percentage, and debug label.
  */
 struct Pose {
-    double x{0.0};              ///< X-coordinate in mm (Cartesian space)
-    double y{0.0};              ///< Y-coordinate in mm (Cartesian space)
-    double z{0.0};              ///< Z-coordinate in mm (Cartesian space)
-    double gripper_percent{0.0};///< Gripper opening percentage (0.0 = fully closed, 100.0 = fully open)
-    std::string label;          ///< Descriptive tag for debugging and logging (e.g., "HOME", "PICK", "PLACE")
+    double x{0.0};               ///< X-coordinate in mm
+    double y{0.0};               ///< Y-coordinate in mm
+    double z{0.0};               ///< Z-coordinate in mm
+    double gripper_percent{0.0}; ///< Gripper opening percentage (0.0 = fully closed, 100.0 = fully open)
+    std::string label;          ///< Descriptive tag for debugging and logging
 };
 
 /**
@@ -42,11 +54,6 @@ class CoordinateMapperMock {
 public:
     virtual ~CoordinateMapperMock() = default;
 
-    /**
-     * @brief Translates an algebraic chess square (e.g., "e4") to Cartesian 2D coordinates (X, Y).
-     * @param square Algebraic notation string for the board cell.
-     * @return std::pair<double, double> Cartesian coordinates {X, Y} in mm at table surface height (Z = 0).
-     */
     virtual std::pair<double, double> getCoordinates(const std::string& square) const {
         (void)square;
         return {100.0, 100.0}; // Simulated fixed coordinates
@@ -62,38 +69,62 @@ public:
     /**
      * @brief Constructs a MotionPlanner instance.
      * @param mapper Reference to the coordinate mapper interface.
-     * @param safeHeightZ Clearance height in Z (mm) to avoid colliding with other pieces during horizontal moves.
-     * @param pickHeightZ Height in Z (mm) where the gripper grips or releases a chess piece.
+     * @param safeHeightZ Clearance height in Z (mm) to avoid collisions.
+     * @param pickHeightZ Height in Z (mm) for gripping/releasing pieces.
      */
     MotionPlanner(const CoordinateMapperMock& mapper, 
                   double safeHeightZ = 50.0, 
                   double pickHeightZ = 10.0);
 
     /**
-     * @brief Generates a trajectory to move a piece from a source cell to a target cell.
-     * @param from Square notation of source position (e.g., "e2").
-     * @param to Square notation of target position (e.g., "e4").
-     * @return std::vector<Pose> Ordered sequence of poses representing the movement trajectory.
+     * @brief Generates a trajectory to move a piece from source cell to target cell.
      */
     std::vector<Pose> planMove(const std::string& from, const std::string& to);
 
     /**
      * @brief Returns a predefined pose based on the state machine Enum.
-     * @param pos Desired predefined position.
-     * @return Pose Cartesian pose associated with the predefined position.
      */
     Pose getPredefinedPose(PredefinedPosition pos) const;
+
+    /**
+     * @brief Gets the pose for a specific slot in the 2x8 graveyard matrix of a given color.
+     * @param color Color of the captured piece (WHITE or BLACK).
+     * @param slotIndex Slot index within the 2x8 grid (0 to 15).
+     * @return Pose Cartesian position corresponding to the matrix slot.
+     */
+    Pose getGraveyardSlotPose(PieceColor color, std::size_t slotIndex) const;
+
+    /**
+     * @brief Plans a capture trajectory, sending the captured piece to the next free graveyard slot.
+     * @param color Color of the captured piece.
+     * @return Pose Cartesian position of the allocated graveyard slot.
+     */
+    Pose allocateNextGraveyardPose(PieceColor color);
+
+    /**
+     * @brief Resets graveyard occupation indices back to slot 0.
+     */
+    void resetGraveyards();
 
 private:
     const CoordinateMapperMock& mapper_;
     double safeHeightZ_;
     double pickHeightZ_;
 
+    std::size_t white_graveyard_index_{0};
+    std::size_t black_graveyard_index_{0};
+
     static constexpr double GRIPPER_OPEN = 100.0;
     static constexpr double GRIPPER_CLOSED = 0.0;
+    static constexpr std::size_t GRAVEYARD_CAPACITY = 16; // 2x8 matrix
 
     const Pose HOME_POSE = {0.0, 0.0, 150.0, GRIPPER_OPEN, "HOME"};
     const Pose GRAVEYARD_POSE = {200.0, -100.0, 50.0, GRIPPER_OPEN, "GRAVEYARD"};
+    const Pose GRAVEYARD_WHITE_BASE = {200.0, -100.0, 50.0, GRIPPER_OPEN, "GRAVEYARD_WHITE"};
+    const Pose GRAVEYARD_BLACK_BASE = {-200.0, -100.0, 50.0, GRIPPER_OPEN, "GRAVEYARD_BLACK"};
+
+    static constexpr double SLOT_SPACING_X = 20.0;
+    static constexpr double SLOT_SPACING_Y = 20.0;
 };
 
 } // namespace ac::motion

--- a/software/acmotion/include/motion/motion_planner.hpp
+++ b/software/acmotion/include/motion/motion_planner.hpp
@@ -49,6 +49,10 @@ class CoordinateMapperMock {
 public:
     virtual ~CoordinateMapperMock() = default;
 
+    /**
+     * @param square Algebraic notation string for the board cell.
+     * @return std::pair<double, double> Cartesian coordinates {X, Y} in mm at table surface height (Z=0).
+     */
     virtual std::pair<double, double> getCoordinates(const std::string& square) const {
         (void)square;
         return {100.0, 100.0}; // Simulated fixed coordinates
@@ -73,11 +77,16 @@ public:
 
     /**
      * @brief Generates a trajectory to move a piece from source cell to target cell.
+     * @param from Algebraic notation of the starting square (e.g., "e2").
+     * @param to Algebraic notation of the destination square (e.g., "e4").
+     * @return std::vector<Pose> Sequence of 3D poses defining the pick-and-place movement.
      */
     std::vector<Pose> planMove(const std::string& from, const std::string& to);
 
     /**
      * @brief Returns a predefined pose based on the state machine Enum.
+     * @param pos Desired predefined position.
+     * @return Pose Cartesian pose associated with the predefined position.
      */
     Pose getPredefinedPose(PredefinedPosition pos) const;
 

--- a/software/acmotion/include/motion/motion_planner.hpp
+++ b/software/acmotion/include/motion/motion_planner.hpp
@@ -5,6 +5,10 @@
 #include <vector>
 #include <utility>
 #include <cstddef>
+#include <map>
+
+// Inclui a definição oficial de Piece, PieceType e PieceColor do módulo acchess
+#include "../../acchess/include/board/piece.hpp"
 
 /**
  * @file motion_planner.hpp
@@ -26,22 +30,13 @@ enum class PredefinedPosition {
 };
 
 /**
- * @enum PieceColor
- * @brief Represents the color of a chess piece for graveyard matrix indexing.
- */
-enum class PieceColor {
-    WHITE,
-    BLACK
-};
-
-/**
  * @struct Pose
  * @brief Represents a 3D Cartesian position, gripper aperture percentage, and debug label.
  */
 struct Pose {
-    double x{0.0};               ///< X-coordinate in mm
-    double y{0.0};               ///< Y-coordinate in mm
-    double z{0.0};               ///< Z-coordinate in mm
+    double x{0.0};              ///< X-coordinate in mm
+    double y{0.0};              ///< Y-coordinate in mm
+    double z{0.0};              ///< Z-coordinate in mm
     double gripper_percent{0.0}; ///< Gripper opening percentage (0.0 = fully closed, 100.0 = fully open)
     std::string label;          ///< Descriptive tag for debugging and logging
 };
@@ -87,36 +82,45 @@ public:
     Pose getPredefinedPose(PredefinedPosition pos) const;
 
     /**
-     * @brief Gets the pose for a specific slot in the 2x8 graveyard matrix of a given color.
-     * @param color Color of the captured piece (WHITE or BLACK).
-     * @param slotIndex Slot index within the 2x8 grid (0 to 15).
-     * @return Pose Cartesian position corresponding to the matrix slot.
+     * @brief Gets the pose for a specific piece type and index in the graveyard matrix.
+     * @param color Color of the captured piece (PieceColor::White or PieceColor::Black).
+     * @param type Type of the piece (PieceType::Pawn, PieceType::Rook, etc.).
+     * @param indexInType Sub-index for that specific piece type (0 to max capacity for type).
      */
-    Pose getGraveyardSlotPose(PieceColor color, std::size_t slotIndex) const;
+    Pose getGraveyardSlotPose(PieceColor color, PieceType type, std::size_t indexInType) const;
 
     /**
-     * @brief Plans a capture trajectory, sending the captured piece to the next free graveyard slot.
+     * @brief Plans a capture trajectory, sending the captured piece to the next free graveyard slot of its type.
      * @param color Color of the captured piece.
-     * @return Pose Cartesian position of the allocated graveyard slot.
+     * @param type Type of the captured piece.
      */
-    Pose allocateNextGraveyardPose(PieceColor color);
+    Pose allocateNextGraveyardPose(PieceColor color, PieceType type);
 
     /**
-     * @brief Resets graveyard occupation indices back to slot 0.
+     * @brief Overload accepting a full Piece struct for convenience.
+     */
+    Pose allocateNextGraveyardPose(const Piece& piece) {
+        return allocateNextGraveyardPose(piece.color, piece.type);
+    }
+
+    /**
+     * @brief Resets graveyard occupation indices for all piece types.
      */
     void resetGraveyards();
 
 private:
+    static std::size_t getMaxCapacityForType(PieceType type);
+    static std::pair<std::size_t, std::size_t> getSlotGridPosition(PieceType type, std::size_t indexInType);
+
     const CoordinateMapperMock& mapper_;
     double safeHeightZ_;
     double pickHeightZ_;
 
-    std::size_t white_graveyard_index_{0};
-    std::size_t black_graveyard_index_{0};
+    // Controle de ocupação por pares (Cor, Tipo de Peça)
+    std::map<std::pair<PieceColor, PieceType>, std::size_t> graveyard_counts_;
 
     static constexpr double GRIPPER_OPEN = 100.0;
     static constexpr double GRIPPER_CLOSED = 0.0;
-    static constexpr std::size_t GRAVEYARD_CAPACITY = 16; // 2x8 matrix
 
     const Pose HOME_POSE = {0.0, 0.0, 150.0, GRIPPER_OPEN, "HOME"};
     const Pose GRAVEYARD_POSE = {200.0, -100.0, 50.0, GRIPPER_OPEN, "GRAVEYARD"};

--- a/software/acmotion/src/motion_planner.cpp
+++ b/software/acmotion/src/motion_planner.cpp
@@ -4,6 +4,8 @@
  */
 
 #include "motion/motion_planner.hpp"
+#include <algorithm>
+#include <stdexcept>
 
 namespace ac::motion {
 
@@ -18,6 +20,12 @@ Pose MotionPlanner::getPredefinedPose(PredefinedPosition pos) const {
             return HOME_POSE;
         case PredefinedPosition::GRAVEYARD:
             return GRAVEYARD_POSE;
+        case PredefinedPosition::GRAVEYARD_WHITE:
+            return GRAVEYARD_WHITE_BASE;
+        case PredefinedPosition::GRAVEYARD_BLACK:
+            return GRAVEYARD_BLACK_BASE;
+        case PredefinedPosition::SAFE_STAGING:
+            return {0.0, 0.0, safeHeightZ_, GRIPPER_OPEN, "SAFE_STAGING"};
         default:
             return HOME_POSE;
     }
@@ -54,6 +62,44 @@ std::vector<Pose> MotionPlanner::planMove(const std::string& from, const std::st
     trajectory.push_back({toX, toY, safeHeightZ_, GRIPPER_OPEN, "RETRACT"});
 
     return trajectory;
+}
+
+Pose MotionPlanner::getGraveyardSlotPose(PieceColor color, std::size_t slotIndex) const {
+    if (slotIndex >= GRAVEYARD_CAPACITY) {
+        throw std::out_of_range("Graveyard slot index exceeds maximum capacity of 16 (2x8 matrix).");
+    }
+
+    // Layout: 2 rows x 8 columns
+    std::size_t row = slotIndex / 8;
+    std::size_t col = slotIndex % 8;
+
+    Pose base = (color == PieceColor::WHITE) ? GRAVEYARD_WHITE_BASE : GRAVEYARD_BLACK_BASE;
+
+    // Calculate grid displacement
+    double targetX = base.x + (col * SLOT_SPACING_X);
+    double targetY = base.y + (row * SLOT_SPACING_Y);
+
+    std::string label = (color == PieceColor::WHITE ? "GRAVEYARD_WHITE_SLOT_" : "GRAVEYARD_BLACK_SLOT_") 
+                      + std::to_string(slotIndex);
+
+    return {targetX, targetY, base.z, base.gripper_percent, label};
+}
+
+Pose MotionPlanner::allocateNextGraveyardPose(PieceColor color) {
+    std::size_t& index = (color == PieceColor::WHITE) ? white_graveyard_index_ : black_graveyard_index_;
+
+    if (index >= GRAVEYARD_CAPACITY) {
+        throw std::out_of_range("Graveyard matrix is fully occupied.");
+    }
+
+    Pose allocatedPose = getGraveyardSlotPose(color, index);
+    index++; // Advance to the next free slot
+    return allocatedPose;
+}
+
+void MotionPlanner::resetGraveyards() {
+    white_graveyard_index_ = 0;
+    black_graveyard_index_ = 0;
 }
 
 } // namespace ac::motion

--- a/software/acmotion/src/motion_planner.cpp
+++ b/software/acmotion/src/motion_planner.cpp
@@ -1,18 +1,95 @@
-/**
- * @file motion_planner.cpp
- * @brief Implementation of the MotionPlanner trajectory generation methods.
- */
-
 #include "motion/motion_planner.hpp"
-#include <algorithm>
 #include <stdexcept>
+#include <algorithm>
 
 namespace ac::motion {
 
 MotionPlanner::MotionPlanner(const CoordinateMapperMock& mapper, 
                              double safeHeightZ, 
                              double pickHeightZ)
-    : mapper_(mapper), safeHeightZ_(safeHeightZ), pickHeightZ_(pickHeightZ) {}
+    : mapper_(mapper), safeHeightZ_(safeHeightZ), pickHeightZ_(pickHeightZ) {
+    resetGraveyards();
+}
+
+void MotionPlanner::resetGraveyards() {
+    graveyard_counts_.clear();
+}
+
+std::size_t MotionPlanner::getMaxCapacityForType(PieceType type) {
+    switch (type) {
+        case PieceType::Pawn:   return 8;
+        case PieceType::Rook:   return 2;
+        case PieceType::Knight: return 2;
+        case PieceType::Bishop: return 2;
+        case PieceType::Queen:  return 1;
+        case PieceType::King:   return 1;
+        default:
+            throw std::invalid_argument("Tipo de peca invalido ou nao suportado no Graveyard.");
+    }
+}
+
+std::pair<std::size_t, std::size_t> MotionPlanner::getSlotGridPosition(PieceType type, std::size_t indexInType) {
+    std::size_t maxCap = getMaxCapacityForType(type);
+    if (indexInType >= maxCap) {
+        throw std::out_of_range("Indice de peca excede a capacidade maxima permitida para este tipo.");
+    }
+
+    // Linha 0 (8 slots): Peões (Pawn)
+    // Linha 1 (8 slots): Peças Nobres (Rook, Knight, Bishop, Queen, King)
+    switch (type) {
+        case PieceType::Pawn:
+            return {0, indexInType}; // Colunas 0 a 7
+        case PieceType::Rook:
+            return {1, indexInType}; // Colunas 0 e 1
+        case PieceType::Knight:
+            return {1, 2 + indexInType}; // Colunas 2 e 3
+        case PieceType::Bishop:
+            return {1, 4 + indexInType}; // Colunas 4 e 5
+        case PieceType::Queen:
+            return {1, 6}; // Coluna 6
+        case PieceType::King:
+            return {1, 7}; // Coluna 7
+        default:
+            throw std::invalid_argument("Tipo de peca invalido.");
+    }
+}
+
+Pose MotionPlanner::getGraveyardSlotPose(PieceColor color, PieceType type, std::size_t indexInType) const {
+    if (color == PieceColor::None || type == PieceType::None) {
+        throw std::invalid_argument("Cor e Tipo de peca devem ser validos.");
+    }
+
+    auto [row, col] = getSlotGridPosition(type, indexInType);
+
+    // Define a pose base de acordo com a cor
+    Pose basePose = (color == PieceColor::White) ? GRAVEYARD_WHITE_BASE : GRAVEYARD_BLACK_BASE;
+
+    // Aplica os offsets espaciais da matriz 2x8
+    basePose.x += (col * SLOT_SPACING_X);
+    basePose.y += (row * SLOT_SPACING_Y);
+    basePose.label = "GRAVEYARD_SLOT_" + std::to_string(row) + "_" + std::to_string(col);
+
+    return basePose;
+}
+
+Pose MotionPlanner::allocateNextGraveyardPose(PieceColor color, PieceType type) {
+    if (color == PieceColor::None || type == PieceType::None) {
+        throw std::invalid_argument("Cor e Tipo de peca devem ser validos.");
+    }
+
+    auto key = std::make_pair(color, type);
+    std::size_t currentIndex = graveyard_counts_[key];
+    std::size_t maxCap = getMaxCapacityForType(type);
+
+    if (currentIndex >= maxCap) {
+        throw std::out_of_range("Graveyard cheio para este tipo de peca especifico.");
+    }
+
+    Pose pose = getGraveyardSlotPose(color, type, currentIndex);
+    graveyard_counts_[key]++; // Incrementa o contador apenas daquele par (Cor, Tipo)
+    
+    return pose;
+}
 
 Pose MotionPlanner::getPredefinedPose(PredefinedPosition pos) const {
     switch (pos) {
@@ -27,79 +104,30 @@ Pose MotionPlanner::getPredefinedPose(PredefinedPosition pos) const {
         case PredefinedPosition::SAFE_STAGING:
             return {0.0, 0.0, safeHeightZ_, GRIPPER_OPEN, "SAFE_STAGING"};
         default:
-            return HOME_POSE;
+            throw std::invalid_argument("Posicao predefinida desconhecida.");
     }
 }
 
 std::vector<Pose> MotionPlanner::planMove(const std::string& from, const std::string& to) {
-    std::vector<Pose> trajectory;
-
     auto [fromX, fromY] = mapper_.getCoordinates(from);
     auto [toX, toY]     = mapper_.getCoordinates(to);
 
-    // 1. Move to safe height above source
+    std::vector<Pose> trajectory;
+
+    // 1. Deslocamento para posicao segura sobre a origem
     trajectory.push_back({fromX, fromY, safeHeightZ_, GRIPPER_OPEN, "APPROACH_SOURCE"});
-
-    // 2. Lower to grasp piece
-    trajectory.push_back({fromX, fromY, pickHeightZ_, GRIPPER_OPEN, "LOWER_TO_SOURCE"});
-
-    // 3. Close gripper
-    trajectory.push_back({fromX, fromY, pickHeightZ_, GRIPPER_CLOSED, "GRASP_PIECE"});
-
-    // 4. Lift piece to safe height
+    // 2. Descida para pegar a peca
+    trajectory.push_back({fromX, fromY, pickHeightZ_, GRIPPER_CLOSED, "PICK_PIECE"});
+    // 3. Subida com a peca presa
     trajectory.push_back({fromX, fromY, safeHeightZ_, GRIPPER_CLOSED, "LIFT_PIECE"});
-
-    // 5. Move horizontally to safe height above target
+    // 4. Deslocamento horizontal seguro para o destino
     trajectory.push_back({toX, toY, safeHeightZ_, GRIPPER_CLOSED, "APPROACH_TARGET"});
-
-    // 6. Lower to target height
-    trajectory.push_back({toX, toY, pickHeightZ_, GRIPPER_CLOSED, "LOWER_TO_TARGET"});
-
-    // 7. Open gripper
+    // 5. Descida para soltar a peca
     trajectory.push_back({toX, toY, pickHeightZ_, GRIPPER_OPEN, "RELEASE_PIECE"});
-
-    // 8. Retract to safe height
+    // 6. Retorno para altura de seguranca
     trajectory.push_back({toX, toY, safeHeightZ_, GRIPPER_OPEN, "RETRACT"});
 
     return trajectory;
-}
-
-Pose MotionPlanner::getGraveyardSlotPose(PieceColor color, std::size_t slotIndex) const {
-    if (slotIndex >= GRAVEYARD_CAPACITY) {
-        throw std::out_of_range("Graveyard slot index exceeds maximum capacity of 16 (2x8 matrix).");
-    }
-
-    // Layout: 2 rows x 8 columns
-    std::size_t row = slotIndex / 8;
-    std::size_t col = slotIndex % 8;
-
-    Pose base = (color == PieceColor::WHITE) ? GRAVEYARD_WHITE_BASE : GRAVEYARD_BLACK_BASE;
-
-    // Calculate grid displacement
-    double targetX = base.x + (col * SLOT_SPACING_X);
-    double targetY = base.y + (row * SLOT_SPACING_Y);
-
-    std::string label = (color == PieceColor::WHITE ? "GRAVEYARD_WHITE_SLOT_" : "GRAVEYARD_BLACK_SLOT_") 
-                      + std::to_string(slotIndex);
-
-    return {targetX, targetY, base.z, base.gripper_percent, label};
-}
-
-Pose MotionPlanner::allocateNextGraveyardPose(PieceColor color) {
-    std::size_t& index = (color == PieceColor::WHITE) ? white_graveyard_index_ : black_graveyard_index_;
-
-    if (index >= GRAVEYARD_CAPACITY) {
-        throw std::out_of_range("Graveyard matrix is fully occupied.");
-    }
-
-    Pose allocatedPose = getGraveyardSlotPose(color, index);
-    index++; // Advance to the next free slot
-    return allocatedPose;
-}
-
-void MotionPlanner::resetGraveyards() {
-    white_graveyard_index_ = 0;
-    black_graveyard_index_ = 0;
 }
 
 } // namespace ac::motion

--- a/software/acmotion/tests/test_motion_planner.cpp
+++ b/software/acmotion/tests/test_motion_planner.cpp
@@ -1,26 +1,73 @@
 #include <gtest/gtest.h>
-#include "../include/motion/motion_planner.hpp"
+#include "motion/motion_planner.hpp"
+#include <stdexcept>
 
 using namespace ac::motion;
 
-// Teste de Poses Pré-definidas
-TEST(MotionPlannerTest, PredefinedPoses) {
+class MotionPlannerTest : public ::testing::Test {
+protected:
     CoordinateMapperMock mapper;
-    MotionPlanner planner(mapper);
+    MotionPlanner planner{mapper, 50.0, 10.0};
+};
 
+TEST_F(MotionPlannerTest, PredefinedPosesReturnCorrectCoordinates) {
     Pose home = planner.getPredefinedPose(PredefinedPosition::HOME);
-    EXPECT_DOUBLE_EQ(home.x, 0.0);
-    EXPECT_DOUBLE_EQ(home.y, 0.0);
-    EXPECT_DOUBLE_EQ(home.z, 150.0);
+    EXPECT_EQ(home.x, 0.0);
+    EXPECT_EQ(home.y, 0.0);
+    EXPECT_EQ(home.z, 150.0);
+
+    Pose whiteBase = planner.getPredefinedPose(PredefinedPosition::GRAVEYARD_WHITE);
+    EXPECT_EQ(whiteBase.x, 200.0);
+    EXPECT_EQ(whiteBase.y, -100.0);
+
+    Pose blackBase = planner.getPredefinedPose(PredefinedPosition::GRAVEYARD_BLACK);
+    EXPECT_EQ(blackBase.x, -200.0);
+    EXPECT_EQ(blackBase.y, -100.0);
 }
 
-// Teste de geração de trajetória básica (planMove)
-TEST(MotionPlannerTest, PlanBasicMove) {
-    CoordinateMapperMock mapper;
-    MotionPlanner planner(mapper);
+TEST_F(MotionPlannerTest, GraveyardMatrixSlotCalculation) {
+    // Test slot 0 (row 0, col 0)
+    Pose whiteSlot0 = planner.getGraveyardSlotPose(PieceColor::WHITE, 0);
+    EXPECT_EQ(whiteSlot0.x, 200.0);
+    EXPECT_EQ(whiteSlot0.y, -100.0);
 
+    // Test slot 1 (row 0, col 1 -> +20mm in X)
+    Pose whiteSlot1 = planner.getGraveyardSlotPose(PieceColor::WHITE, 1);
+    EXPECT_EQ(whiteSlot1.x, 220.0);
+    EXPECT_EQ(whiteSlot1.y, -100.0);
+
+    // Test slot 8 (row 1, col 0 -> +20mm in Y)
+    Pose whiteSlot8 = planner.getGraveyardSlotPose(PieceColor::WHITE, 8);
+    EXPECT_EQ(whiteSlot8.x, 200.0);
+    EXPECT_EQ(whiteSlot8.y, -80.0);
+}
+
+TEST_F(MotionPlannerTest, SequentialAllocationAdvancesSlots) {
+    planner.resetGraveyards();
+
+    Pose firstPiece = planner.allocateNextGraveyardPose(PieceColor::WHITE);
+    EXPECT_EQ(firstPiece.label, "GRAVEYARD_WHITE_SLOT_0");
+
+    Pose secondPiece = planner.allocateNextGraveyardPose(PieceColor::WHITE);
+    EXPECT_EQ(secondPiece.label, "GRAVEYARD_WHITE_SLOT_1");
+
+    // Check that black graveyard index remains independent
+    Pose blackPiece = planner.allocateNextGraveyardPose(PieceColor::BLACK);
+    EXPECT_EQ(blackPiece.label, "GRAVEYARD_BLACK_SLOT_0");
+}
+
+TEST_F(MotionPlannerTest, GraveyardCapacityThrowsOnOverflow) {
+    planner.resetGraveyards();
+
+    for (std::size_t i = 0; i < 16; ++i) {
+        EXPECT_NO_THROW(planner.allocateNextGraveyardPose(PieceColor::WHITE));
+    }
+
+    // 17th piece should throw out_of_range
+    EXPECT_THROW(planner.allocateNextGraveyardPose(PieceColor::WHITE), std::out_of_range);
+}
+
+TEST_F(MotionPlannerTest, PlanMoveGeneratesExpectedTrajectorySize) {
     auto trajectory = planner.planMove("e2", "e4");
-
-    // Garante que a trajetória foi gerada
-    EXPECT_FALSE(trajectory.empty());
+    EXPECT_EQ(trajectory.size(), 8);
 }

--- a/software/acmotion/tests/test_motion_planner.cpp
+++ b/software/acmotion/tests/test_motion_planner.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
-#include "motion/motion_planner.hpp"
 #include <stdexcept>
+#include "../include/motion/motion_planner.hpp"
 
 using namespace ac::motion;
 
@@ -10,64 +10,49 @@ protected:
     MotionPlanner planner{mapper, 50.0, 10.0};
 };
 
-TEST_F(MotionPlannerTest, PredefinedPosesReturnCorrectCoordinates) {
-    Pose home = planner.getPredefinedPose(PredefinedPosition::HOME);
-    EXPECT_EQ(home.x, 0.0);
-    EXPECT_EQ(home.y, 0.0);
-    EXPECT_EQ(home.z, 150.0);
+TEST_F(MotionPlannerTest, GraveyardAllocationTypeSeparation) {
+    // Alocar um Peão Branco não deve consumir o slot de uma Torre Branca
+    Pose pawnPose = planner.allocateNextGraveyardPose(PieceColor::White, PieceType::Pawn);
+    Pose rookPose = planner.allocateNextGraveyardPose(PieceColor::White, PieceType::Rook);
 
-    Pose whiteBase = planner.getPredefinedPose(PredefinedPosition::GRAVEYARD_WHITE);
-    EXPECT_EQ(whiteBase.x, 200.0);
-    EXPECT_EQ(whiteBase.y, -100.0);
+    // Peões ficam na linha 0 e Torres na linha 1 (diferentes posições Y)
+    EXPECT_NE(pawnPose.y, rookPose.y);
 
-    Pose blackBase = planner.getPredefinedPose(PredefinedPosition::GRAVEYARD_BLACK);
-    EXPECT_EQ(blackBase.x, -200.0);
-    EXPECT_EQ(blackBase.y, -100.0);
-}
-
-TEST_F(MotionPlannerTest, GraveyardMatrixSlotCalculation) {
-    // Test slot 0 (row 0, col 0)
-    Pose whiteSlot0 = planner.getGraveyardSlotPose(PieceColor::WHITE, 0);
-    EXPECT_EQ(whiteSlot0.x, 200.0);
-    EXPECT_EQ(whiteSlot0.y, -100.0);
-
-    // Test slot 1 (row 0, col 1 -> +20mm in X)
-    Pose whiteSlot1 = planner.getGraveyardSlotPose(PieceColor::WHITE, 1);
-    EXPECT_EQ(whiteSlot1.x, 220.0);
-    EXPECT_EQ(whiteSlot1.y, -100.0);
-
-    // Test slot 8 (row 1, col 0 -> +20mm in Y)
-    Pose whiteSlot8 = planner.getGraveyardSlotPose(PieceColor::WHITE, 8);
-    EXPECT_EQ(whiteSlot8.x, 200.0);
-    EXPECT_EQ(whiteSlot8.y, -80.0);
-}
-
-TEST_F(MotionPlannerTest, SequentialAllocationAdvancesSlots) {
-    planner.resetGraveyards();
-
-    Pose firstPiece = planner.allocateNextGraveyardPose(PieceColor::WHITE);
-    EXPECT_EQ(firstPiece.label, "GRAVEYARD_WHITE_SLOT_0");
-
-    Pose secondPiece = planner.allocateNextGraveyardPose(PieceColor::WHITE);
-    EXPECT_EQ(secondPiece.label, "GRAVEYARD_WHITE_SLOT_1");
-
-    // Check that black graveyard index remains independent
-    Pose blackPiece = planner.allocateNextGraveyardPose(PieceColor::BLACK);
-    EXPECT_EQ(blackPiece.label, "GRAVEYARD_BLACK_SLOT_0");
-}
-
-TEST_F(MotionPlannerTest, GraveyardCapacityThrowsOnOverflow) {
-    planner.resetGraveyards();
-
-    for (std::size_t i = 0; i < 16; ++i) {
-        EXPECT_NO_THROW(planner.allocateNextGraveyardPose(PieceColor::WHITE));
+    // Preencher o limite máximo de peões brancos (8 peões)
+    for (int i = 0; i < 7; ++i) {
+        EXPECT_NO_THROW(planner.allocateNextGraveyardPose(PieceColor::White, PieceType::Pawn));
     }
 
-    // 17th piece should throw out_of_range
-    EXPECT_THROW(planner.allocateNextGraveyardPose(PieceColor::WHITE), std::out_of_range);
+    // O 9º peão deve lançar exceção out_of_range
+    EXPECT_THROW(planner.allocateNextGraveyardPose(PieceColor::White, PieceType::Pawn), std::out_of_range);
+
+    // Mas ainda deve ser possível alocar a segunda Torre Branca normalmente
+    EXPECT_NO_THROW(planner.allocateNextGraveyardPose(PieceColor::White, PieceType::Rook));
 }
 
-TEST_F(MotionPlannerTest, PlanMoveGeneratesExpectedTrajectorySize) {
-    auto trajectory = planner.planMove("e2", "e4");
-    EXPECT_EQ(trajectory.size(), 8);
+TEST_F(MotionPlannerTest, GraveyardColorIndependence) {
+    // A alocação de peças brancas e pretas deve ser independente
+    Pose whitePawn = planner.allocateNextGraveyardPose(PieceColor::White, PieceType::Pawn);
+    Pose blackPawn = planner.allocateNextGraveyardPose(PieceColor::Black, PieceType::Pawn);
+
+    // As coordenadas X devem ser opostas/distintas devido às bases diferentes
+    EXPECT_NE(whitePawn.x, blackPawn.x);
+}
+
+TEST_F(MotionPlannerTest, InvalidPieceTypeHandling) {
+    // Tentar alocar peça sem cor ou sem tipo deve lançar invalid_argument
+    EXPECT_THROW(planner.allocateNextGraveyardPose(PieceColor::None, PieceType::Pawn), std::invalid_argument);
+    EXPECT_THROW(planner.allocateNextGraveyardPose(PieceColor::White, PieceType::None), std::invalid_argument);
+}
+
+TEST_F(MotionPlannerTest, ResetGraveyard) {
+    // Encher peões brancos até o limite
+    for (int i = 0; i < 8; ++i) {
+        planner.allocateNextGraveyardPose(PieceColor::White, PieceType::Pawn);
+    }
+    EXPECT_THROW(planner.allocateNextGraveyardPose(PieceColor::White, PieceType::Pawn), std::out_of_range);
+
+    // Após o reset, deve ser possível alocar novamente
+    planner.resetGraveyards();
+    EXPECT_NO_THROW(planner.allocateNextGraveyardPose(PieceColor::White, PieceType::Pawn));
 }


### PR DESCRIPTION
## Resumo

Implementação das matrizes 2x8 para gerenciamento dos cemitérios de peças capturadas (brancas e pretas) no módulo `acmotion`. A alteração permite que o robô posicione as peças capturadas de forma organizada em grade, evitando colisões e calculando dinamicamente os offsets de descarte.

## Issues Relacionadas

- Closes #96

## Tipo de Alteração

- [x] **Feature** (nova funcionalidade)
- [ ] **Bugfix** (correção de erro)
- [ ] **Refactor** (melhoria de código sem alterar regra de negócio)
- [ ] **Docs** (documentação)

## Módulos Afetados

- [x] `acmotion`
- [ ] `acchess`
- [ ] `acvision`

## Impacto Arquitetural

- Adicionado suporte às posições `GRAVEYARD_WHITE` e `GRAVEYARD_BLACK` mantendo compatibilidade com o legado `GRAVEYARD`.
- Criado o método `getGraveyardSlotPose()` para cálculo geométrico da grade de 16 posições (2x8) com espaçamento configurável em X e Y.
- Adicionado o método `allocateNextGraveyardPose()` para controle sequencial e automático do próximo slot livre de cada cor.
- Implementado tratamento de exceção (`std::out_of_range`) para prevenir transbordamento de capacidade no cemitério.

## Estratégia / Casos Especiais

- **Captura e Descarte:** As peças brancas e pretas têm contadores independentes de 0 a 15. Ao realizar uma captura, o robô consulta o próximo slot livre relativo à cor da peça desfeita.

## Testes Realizados

- [x] Testes unitários com GTest atualizados em `software/acmotion/tests/test_motion_planner.cpp`.
- [x] Validação das coordenadas (X, Y) para slots das linhas 0 e 1 da matriz.
- [x] Teste de alocação sequencial e independência entre cemitérios.
- [x] Teste de lançamento de exceção ao atingir o limite de 16 peças por cemitério.

## Checklist

- [x] Código compilando sem avisos.
- [x] Testes unitários adicionados/atualizados.
- [x] Segue o padrão de nomenclatura e estilo do projeto.
- [x] Pronto para revisão de código (@oEnzoRibas).