### PR TITLE
Add CoordinateMapper for chessboard calibration and mapping

### DIFF
--- a/Software/acvision/include/coordinate_mapper/coordinate_mapper.hpp
+++ b/Software/acvision/include/coordinate_mapper/coordinate_mapper.hpp
@@ -1,0 +1,197 @@
+#ifndef COORDINATE_MAPPER_HPP
+#define COORDINATE_MAPPER_HPP
+
+#include <string>
+#include <unordered_map>
+
+/**
+ * @brief Representa uma coordenada física no plano XY.
+ *
+ * As coordenadas são expressas no sistema de coordenadas
+ * utilizado pelo robô SCARA.
+ */
+struct Point2D
+{
+    double x;
+    double y;
+};
+
+/**
+ * @brief Realiza o mapeamento entre as casas do tabuleiro
+ *        e as coordenadas físicas do robô.
+ *
+ * O CoordinateMapper é responsável por:
+ *
+ * - realizar a calibração do tabuleiro;
+ * - determinar a origem do tabuleiro;
+ * - determinar a orientação do tabuleiro;
+ * - determinar o tamanho físico das casas;
+ * - gerar as coordenadas das 64 casas;
+ * - armazenar os parâmetros de calibração;
+ * - carregar uma calibração previamente salva;
+ * - converter uma casa de xadrez em coordenadas físicas.
+ *
+ * A calibração é realizada utilizando dois pontos físicos:
+ *
+ * A1 -> origem do tabuleiro
+ * H1 -> extremidade do primeiro eixo
+ *
+ * A partir desses pontos são determinados:
+ *
+ * - origem;
+ * - tamanho da casa;
+ * - rotação do tabuleiro.
+ */
+class CoordinateMapper
+{
+public:
+
+    /**
+     * @brief Construtor.
+     *
+     * Tenta carregar automaticamente uma calibração existente.
+     *
+     * @param config_file Caminho do arquivo de calibração.
+     */
+    explicit CoordinateMapper(
+        const std::string& config_file = "board_calibration.cfg"
+    );
+
+    /**
+     * @brief Verifica se existe uma calibração válida.
+     *
+     * @return true se o sistema estiver calibrado.
+     */
+    bool isCalibrated() const;
+
+    /**
+     * @brief Realiza a calibração do tabuleiro.
+     *
+     * A1 representa a origem do sistema de coordenadas
+     * do tabuleiro.
+     *
+     * H1 é utilizado para determinar:
+     *
+     * - tamanho físico das casas;
+     * - orientação do eixo X do tabuleiro.
+     *
+     * @param a1 Coordenada física da casa A1.
+     * @param h1 Coordenada física da casa H1.
+     *
+     * @throws std::runtime_error se os pontos forem inválidos.
+     */
+    void calibrate(
+        const Point2D& a1,
+        const Point2D& h1
+    );
+
+    /**
+     * @brief Retorna as coordenadas físicas de uma casa.
+     *
+     * Exemplos:
+     *
+     * E2
+     * a1
+     * H8
+     *
+     * A entrada é convertida automaticamente para maiúsculas.
+     *
+     * @param square Casa do tabuleiro.
+     *
+     * @return Coordenada física da casa.
+     *
+     * @throws std::runtime_error se não houver calibração.
+     * @throws std::invalid_argument se a casa for inválida.
+     */
+    Point2D getCoordinates(
+        const std::string& square
+    ) const;
+
+private:
+
+    /**
+     * @brief Coordenada X da origem do tabuleiro.
+     */
+    double origin_x;
+
+    /**
+     * @brief Coordenada Y da origem do tabuleiro.
+     */
+    double origin_y;
+
+    /**
+     * @brief Tamanho físico de uma casa.
+     */
+    double square_size;
+
+    /**
+     * @brief Rotação do tabuleiro em radianos.
+     */
+    double rotation;
+
+    /**
+     * @brief Indica se existe uma calibração válida.
+     */
+    bool calibrated;
+
+    /**
+     * @brief Caminho do arquivo de configuração.
+     */
+    std::string config_path;
+
+    /**
+     * @brief Mapa das 64 casas do tabuleiro.
+     *
+     * A chave representa a casa:
+     *
+     * A1, A2, ..., H8
+     *
+     * O valor representa a coordenada física correspondente.
+     */
+    std::unordered_map<
+        std::string,
+        Point2D
+    > board_map;
+
+    /**
+     * @brief Gera o mapa das 64 casas.
+     *
+     * Utiliza os parâmetros de calibração para transformar
+     * as coordenadas locais do tabuleiro em coordenadas
+     * físicas do robô.
+     */
+    void generateMap();
+
+    /**
+     * @brief Salva os parâmetros de calibração.
+     *
+     * O arquivo utiliza o formato:
+     *
+     * origin_x=...
+     * origin_y=...
+     * square_size=...
+     * rotation=...
+     *
+     * @throws std::runtime_error se não for possível salvar.
+     */
+    void saveCalibration() const;
+
+    /**
+     * @brief Carrega os parâmetros de calibração.
+     *
+     * @return true se os parâmetros forem carregados e válidos.
+     */
+    bool loadCalibration();
+
+    /**
+     * @brief Valida os parâmetros de calibração.
+     *
+     * Verifica valores inválidos, NaN, infinito e tamanho
+     * de casa menor ou igual a zero.
+     *
+     * @return true se a calibração for válida.
+     */
+    bool validateCalibration() const;
+};
+
+#endif // COORDINATE_MAPPER_HPP

--- a/Software/acvision/src/coordinate_mapper/coordinate_mapper.cpp
+++ b/Software/acvision/src/coordinate_mapper/coordinate_mapper.cpp
@@ -1,0 +1,492 @@
+#include "coordinate_mapper/coordinate_mapper.hpp"
+
+#include <cmath>
+#include <cctype>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+#include <stdexcept>
+
+namespace
+{
+    /**
+     * @brief Constante matemática PI.
+     */
+    constexpr double PI = 3.14159265358979323846;
+}
+
+CoordinateMapper::CoordinateMapper(
+    const std::string& config_file
+)
+    : origin_x(0.0),
+      origin_y(0.0),
+      square_size(0.0),
+      rotation(0.0),
+      calibrated(false),
+      config_path(config_file)
+{
+    /*
+     * O tabuleiro possui exatamente 64 casas.
+     *
+     * Reservamos espaço antecipadamente para evitar
+     * realocações desnecessárias do unordered_map.
+     */
+    board_map.reserve(64);
+
+    /*
+     * Tenta carregar automaticamente a calibração.
+     *
+     * Se o arquivo não existir ou estiver inválido,
+     * calibrated permanecerá false.
+     */
+    calibrated = loadCalibration();
+
+    /*
+     * loadCalibration() apenas carrega os parâmetros.
+     *
+     * Depois que eles são validados, geramos novamente
+     * o mapa das 64 casas.
+     */
+    if (calibrated)
+    {
+        generateMap();
+    }
+}
+
+bool CoordinateMapper::isCalibrated() const
+{
+    return calibrated;
+}
+
+void CoordinateMapper::calibrate(
+    const Point2D& a1,
+    const Point2D& h1
+)
+{
+    /*
+     * A1 representa a origem do sistema de coordenadas
+     * do tabuleiro.
+     */
+    origin_x = a1.x;
+    origin_y = a1.y;
+
+    /*
+     * Calcula o vetor que representa o primeiro eixo
+     * do tabuleiro:
+     *
+     * A1 -> H1
+     */
+    const double dx = h1.x - a1.x;
+    const double dy = h1.y - a1.y;
+
+    /*
+     * Calcula a distância física entre A1 e H1.
+     */
+    const double distance = std::sqrt(
+        (dx * dx) +
+        (dy * dy)
+    );
+
+    /*
+     * A1 e H1 não podem ocupar a mesma posição.
+     */
+    if (distance <= 0.0)
+    {
+        throw std::runtime_error(
+            "Os pontos A1 e H1 devem possuir coordenadas diferentes."
+        );
+    }
+
+    /*
+     * Entre A1 e H1 existem 7 intervalos:
+     *
+     * A1 B1 C1 D1 E1 F1 G1 H1
+     *
+     * Portanto:
+     *
+     * square_size = distancia / 7
+     */
+    square_size = distance / 7.0;
+
+    /*
+     * Determina a orientação do eixo X do tabuleiro.
+     *
+     * atan2 fornece o ângulo em radianos.
+     */
+    rotation = std::atan2(dy, dx);
+
+    /*
+     * Normaliza o ângulo para o intervalo [-PI, PI].
+     *
+     * atan2 já retorna esse intervalo, mas a normalização
+     * mantém a intenção explícita.
+     */
+    if (rotation > PI)
+    {
+        rotation -= 2.0 * PI;
+    }
+    else if (rotation < -PI)
+    {
+        rotation += 2.0 * PI;
+    }
+
+    /*
+     * Verifica se os parâmetros calculados são válidos.
+     */
+    if (!validateCalibration())
+    {
+        calibrated = false;
+
+        throw std::runtime_error(
+            "Os parâmetros calculados para a calibração são inválidos."
+        );
+    }
+
+    calibrated = true;
+
+    /*
+     * Gera as coordenadas das 64 casas.
+     */
+    generateMap();
+
+    /*
+     * Persiste a calibração para as próximas execuções.
+     */
+    saveCalibration();
+}
+
+Point2D CoordinateMapper::getCoordinates(
+    const std::string& square
+) const
+{
+    /*
+     * Não é possível consultar uma posição se o sistema
+     * ainda não estiver calibrado.
+     */
+    if (!calibrated)
+    {
+        throw std::runtime_error(
+            "Sistema de coordenadas não calibrado."
+        );
+    }
+
+    /*
+     * Uma casa válida possui exatamente dois caracteres:
+     *
+     * A1
+     * E2
+     * H8
+     */
+    if (square.size() != 2)
+    {
+        throw std::invalid_argument(
+            "Casa do tabuleiro inválida: " + square
+        );
+    }
+
+    /*
+     * Copia a entrada para que possamos normalizá-la
+     * sem modificar o argumento original.
+     */
+    std::string key = square;
+
+    /*
+     * Converte a coluna para maiúscula.
+     *
+     * e2 -> E2
+     */
+    key[0] = static_cast<char>(
+        std::toupper(
+            static_cast<unsigned char>(key[0])
+        )
+    );
+
+    /*
+     * A busca na tabela hash possui complexidade média O(1).
+     */
+    const auto it = board_map.find(key);
+
+    if (it == board_map.end())
+    {
+        throw std::invalid_argument(
+            "Casa do tabuleiro inválida: " + square
+        );
+    }
+
+    return it->second;
+}
+
+void CoordinateMapper::generateMap()
+{
+    /*
+     * Remove o mapa anterior caso exista.
+     */
+    board_map.clear();
+
+    /*
+     * O tabuleiro possui oito colunas:
+     *
+     * A B C D E F G H
+     */
+    constexpr char files[] = {
+        'A', 'B', 'C', 'D',
+        'E', 'F', 'G', 'H'
+    };
+
+    /*
+     * Pré-calculamos seno e cosseno porque os mesmos valores
+     * serão utilizados nas 64 casas.
+     */
+    const double cos_theta = std::cos(rotation);
+    const double sin_theta = std::sin(rotation);
+
+    /*
+     * Percorre as oito colunas.
+     */
+    for (int file = 0; file < 8; ++file)
+    {
+        /*
+         * Percorre as oito linhas.
+         */
+        for (int rank = 0; rank < 8; ++rank)
+        {
+            /*
+             * Coordenadas no sistema local do tabuleiro.
+             *
+             * A1:
+             *
+             * localX = 0
+             * localY = 0
+             *
+             * B1:
+             *
+             * localX = square_size
+             * localY = 0
+             *
+             * A2:
+             *
+             * localX = 0
+             * localY = square_size
+             */
+            const double local_x =
+                static_cast<double>(file) * square_size;
+
+            const double local_y =
+                static_cast<double>(rank) * square_size;
+
+            /*
+             * Aplicação da transformação de rotação.
+             *
+             * [x']   [ cos -sin ] [x]
+             * [y'] = [ sin  cos ] [y]
+             */
+            Point2D point;
+
+            point.x =
+                origin_x +
+                (local_x * cos_theta) -
+                (local_y * sin_theta);
+
+            point.y =
+                origin_y +
+                (local_x * sin_theta) +
+                (local_y * cos_theta);
+
+            /*
+             * Monta a identificação da casa.
+             *
+             * Exemplos:
+             *
+             * A1
+             * E2
+             * H8
+             */
+            std::string square;
+
+            square += files[file];
+            square += std::to_string(rank + 1);
+
+            /*
+             * Insere no mapa.
+             */
+            board_map[square] = point;
+        }
+    }
+}
+
+bool CoordinateMapper::validateCalibration() const
+{
+    /*
+     * O tamanho da casa precisa ser positivo.
+     */
+    if (square_size <= 0.0)
+    {
+        return false;
+    }
+
+    /*
+     * Verifica NaN.
+     */
+    if (std::isnan(origin_x) ||
+        std::isnan(origin_y) ||
+        std::isnan(square_size) ||
+        std::isnan(rotation))
+    {
+        return false;
+    }
+
+    /*
+     * Verifica infinito.
+     */
+    if (std::isinf(origin_x) ||
+        std::isinf(origin_y) ||
+        std::isinf(square_size) ||
+        std::isinf(rotation))
+    {
+        return false;
+    }
+
+    return true;
+}
+
+void CoordinateMapper::saveCalibration() const
+{
+    /*
+     * Abre o arquivo para escrita.
+     *
+     * O conteúdo anterior será substituído.
+     */
+    std::ofstream file(config_path);
+
+    if (!file)
+    {
+        throw std::runtime_error(
+            "Não foi possível salvar o arquivo de calibração: " +
+            config_path
+        );
+    }
+
+    /*
+     * Utilizamos dez casas decimais para preservar precisão
+     * suficiente para as coordenadas físicas.
+     */
+    file << std::fixed
+         << std::setprecision(10);
+
+    file << "origin_x="
+         << origin_x
+         << '\n';
+
+    file << "origin_y="
+         << origin_y
+         << '\n';
+
+    file << "square_size="
+         << square_size
+         << '\n';
+
+    file << "rotation="
+         << rotation
+         << '\n';
+
+    /*
+     * O fechamento ocorre automaticamente quando o objeto
+     * ofstream sai de escopo.
+     */
+}
+
+bool CoordinateMapper::loadCalibration()
+{
+    /*
+     * Tenta abrir o arquivo.
+     *
+     * Se ele não existir, significa que provavelmente
+     * estamos executando pela primeira vez.
+     */
+    std::ifstream file(config_path);
+
+    if (!file)
+    {
+        return false;
+    }
+
+    std::string line;
+
+    /*
+     * Lê o arquivo linha por linha.
+     */
+    while (std::getline(file, line))
+    {
+        /*
+         * Ignora linhas vazias.
+         */
+        if (line.empty())
+        {
+            continue;
+        }
+
+        std::stringstream stream(line);
+
+        std::string key;
+        std::string value;
+
+        /*
+         * Divide:
+         *
+         * origin_x=150
+         *
+         * em:
+         *
+         * key   = origin_x
+         * value = 150
+         */
+        if (!std::getline(stream, key, '='))
+        {
+            continue;
+        }
+
+        if (!std::getline(stream, value))
+        {
+            continue;
+        }
+
+        try
+        {
+            const double number =
+                std::stod(value);
+
+            if (key == "origin_x")
+            {
+                origin_x = number;
+            }
+            else if (key == "origin_y")
+            {
+                origin_y = number;
+            }
+            else if (key == "square_size")
+            {
+                square_size = number;
+            }
+            else if (key == "rotation")
+            {
+                rotation = number;
+            }
+        }
+        catch (const std::exception&)
+        {
+            /*
+             * Um valor inválido torna a calibração inválida.
+             */
+            calibrated = false;
+
+            return false;
+        }
+    }
+
+    /*
+     * Verifica se todos os parâmetros carregados são válidos.
+     */
+    calibrated = validateCalibration();
+
+    return calibrated;
+}


### PR DESCRIPTION
# Implementação do CoordinateMapper para calibração e mapeamento do tabuleiro

## Objetivo

Implementar o módulo `CoordinateMapper`, responsável por realizar o mapeamento entre as casas do tabuleiro de xadrez e as coordenadas físicas do robô SCARA.

O módulo permite que o sistema realize uma calibração inicial do tabuleiro e reutilize os parâmetros obtidos nas execuções seguintes, evitando recalcular as posições das casas durante a operação normal do robô.

## Alterações realizadas

### CoordinateMapper

Foi implementada a classe `CoordinateMapper` com suporte a:

* calibração da origem do tabuleiro;
* determinação automática do tamanho físico das casas;
* determinação da orientação do tabuleiro;
* geração das coordenadas das 64 casas;
* conversão de notação de xadrez para coordenadas físicas;
* persistência dos parâmetros de calibração;
* carregamento automático da calibração existente;
* validação dos parâmetros carregados.

### Calibração

A calibração utiliza dois pontos físicos:

```text
A1 → origem do tabuleiro
H1 → referência para o eixo horizontal
```

A partir desses pontos são calculados:

```text
square_size = distância(A1, H1) / 7
rotation    = atan2(dy, dx)
```

Isso permite determinar tanto a dimensão das casas quanto a rotação do tabuleiro em relação ao sistema de coordenadas do robô.

### Mapeamento

As coordenadas locais de cada casa são transformadas para o sistema físico do robô utilizando uma transformação de rotação:

```text
x' = x0 + x·cos(θ) - y·sin(θ)
y' = y0 + x·sin(θ) + y·cos(θ)
```

O resultado é armazenado em uma `std::unordered_map`, permitindo consultas com complexidade média O(1).

Exemplo:

```text
E2
 ↓
CoordinateMapper
 ↓
(x, y)
```

### Persistência

Os parâmetros de calibração são armazenados no arquivo:

```text
board_calibration.cfg
```

Formato:

```text
origin_x=...
origin_y=...
square_size=...
rotation=...
```

Na inicialização, o `CoordinateMapper` tenta carregar automaticamente esse arquivo. Caso a calibração seja válida, o mapa das 64 casas é reconstruído sem necessidade de nova calibração.

### Validação

Foram adicionadas validações para:

* tamanho de casa inválido;
* coordenadas `NaN`;
* coordenadas infinitas;
* arquivo de calibração inexistente;
* valores inválidos no arquivo;
* casas de xadrez inexistentes;
* consulta sem calibração válida.

### Organização dos arquivos

O módulo foi organizado seguindo a estrutura existente do projeto:

```text
include/
└── coordinate_mapper/
    └── coordinate_mapper.hpp

src/
└── coordinate_mapper/
   └── coordinate_mapper.cpp

```

## Resultado

O sistema passa a possuir um componente independente responsável exclusivamente pela transformação:

```text
Casa do tabuleiro
       ↓
CoordinateMapper
       ↓
Coordenada física X/Y
       ↓
Módulo de movimento do SCARA
```

A implementação mantém a calibração separada da operação normal do robô, permitindo que as posições das casas sejam determinadas uma única vez e reutilizadas durante toda a execução.

## Fora do escopo

Este PR não implementa:

* cinemática inversa do SCARA;
* conversão de `(X, Y)` para ângulos dos motores;
* controle dos motores;
* detecção visual do tabuleiro;
* detecção das peças;
* planejamento de trajetória.

Essas responsabilidades devem permanecer em módulos específicos e utilizar o `CoordinateMapper` como fornecedor das coordenadas físicas do tabuleiro.
